### PR TITLE
Remove go 1.9 dependency

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -23,7 +23,7 @@ import (
 
 // mageVer is used when hashing the output binary to ensure that we get a new
 // binary if we use a differernt version of mage.
-const mageVer = "v0.2"
+const mageVer = "v0.3"
 
 var output = template.Must(template.New("").Funcs(map[string]interface{}{
 	"lower": strings.ToLower,

--- a/mage/template.go
+++ b/mage/template.go
@@ -46,9 +46,9 @@ func main() {
 		err := recover()
 		if err != nil {
 			fmt.Println(err)
-			type code interface { ExitCode() int }
+			type code interface { ExitStatus() int }
 			if c, ok := err.(code); ok {
-				os.Exit(c.ExitCode())
+				os.Exit(c.ExitStatus())
 			}
 			os.Exit(1)
 		}

--- a/mg/deps.go
+++ b/mg/deps.go
@@ -10,7 +10,27 @@ import (
 	"github.com/pkg/errors"
 )
 
-var onces = &sync.Map{}
+type onceMap struct {
+	mu *sync.Mutex
+	m  map[string]*onceFun
+}
+
+func (o *onceMap) LoadOrStore(s string, one *onceFun) *onceFun {
+	defer o.mu.Unlock()
+	o.mu.Lock()
+
+	existing, ok := o.m[s]
+	if ok {
+		return existing
+	}
+	o.m[s] = one
+	return one
+}
+
+var onces = &onceMap{
+	mu: &sync.Mutex{},
+	m:  map[string]*onceFun{},
+}
 
 // Deps runs the given functions as dependencies of the calling function.
 // Dependencies must only be func() or func() error.  The function calling Deps
@@ -37,8 +57,8 @@ func Deps(fns ...interface{}) {
 			defer func() {
 				if err := recover(); err != nil {
 					mu.Lock()
-					if c, ok := err.(exitCoder); ok {
-						exit = changeExit(exit, c.ExitCode())
+					if e, ok := err.(exitStatus); ok {
+						exit = changeExit(exit, e.ExitStatus())
 					}
 					errs = append(errs, fmt.Sprint(err))
 					mu.Unlock()
@@ -56,10 +76,7 @@ func Deps(fns ...interface{}) {
 
 	wg.Wait()
 	if len(errs) > 0 {
-		panic(fatalErr{
-			msg:  strings.Join(errs, "\n"),
-			code: exit,
-		})
+		panic(Fatal(exit, strings.Join(errs, "\n")))
 	}
 }
 
@@ -88,10 +105,10 @@ func addDep(f interface{}) *onceFun {
 	}
 
 	n := name(f)
-	of, _ := onces.LoadOrStore(n, &onceFun{
+	of := onces.LoadOrStore(n, &onceFun{
 		fn: fn,
 	})
-	return of.(*onceFun)
+	return of
 }
 
 func name(i interface{}) string {
@@ -109,21 +126,4 @@ func (o *onceFun) run() error {
 		err = o.fn()
 	})
 	return err
-}
-
-type exitCoder interface {
-	ExitCode() int
-}
-
-type fatalErr struct {
-	msg  string
-	code int
-}
-
-func (f fatalErr) Error() string {
-	return f.msg
-}
-
-func (f fatalErr) ExitCode() int {
-	return f.code
 }

--- a/mg/deps_test.go
+++ b/mg/deps_test.go
@@ -71,3 +71,23 @@ func TestDepError(t *testing.T) {
 	}()
 	mg.Deps(f)
 }
+
+func TestDepFatal(t *testing.T) {
+	// TODO: this test is ugly and relies on implementation details. It should
+	// be recreated as a full-stack test.
+
+	f := func() error {
+		return mg.Fatal(99, "ouch!")
+	}
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatal("expected panic, but didn't get one")
+		}
+		actual := fmt.Sprint(err)
+		if "ouch!" != actual {
+			t.Fatalf(`expected to get "ouch!" but got "%s"`, actual)
+		}
+	}()
+	mg.Deps(f)
+}

--- a/mg/deps_test.go
+++ b/mg/deps_test.go
@@ -73,21 +73,57 @@ func TestDepError(t *testing.T) {
 }
 
 func TestDepFatal(t *testing.T) {
-	// TODO: this test is ugly and relies on implementation details. It should
-	// be recreated as a full-stack test.
-
 	f := func() error {
 		return mg.Fatal(99, "ouch!")
 	}
 	defer func() {
-		err := recover()
-		if err == nil {
+		v := recover()
+		if v == nil {
 			t.Fatal("expected panic, but didn't get one")
 		}
-		actual := fmt.Sprint(err)
+		actual := fmt.Sprint(v)
 		if "ouch!" != actual {
 			t.Fatalf(`expected to get "ouch!" but got "%s"`, actual)
 		}
+		err, ok := v.(error)
+		if !ok {
+			t.Fatalf("expected recovered val to be error but was %T", v)
+		}
+		code := mg.ExitStatus(err)
+		if code != 99 {
+			t.Fatalf("Expected exit status 99, but got %v", code)
+		}
 	}()
 	mg.Deps(f)
+}
+
+func TestDepTwoFatal(t *testing.T) {
+	f := func() error {
+		return mg.Fatal(99, "ouch!")
+	}
+	g := func() error {
+		return mg.Fatal(11, "bang!")
+	}
+	defer func() {
+		v := recover()
+		if v == nil {
+			t.Fatal("expected panic, but didn't get one")
+		}
+		actual := fmt.Sprint(v)
+		// order is non-deterministic, so check for both orders
+		if "ouch!\nbang!" != actual && "bang!\nouch!" != actual {
+			t.Fatalf(`expected to get "ouch!" and "bang!" but got "%s"`, actual)
+		}
+		err, ok := v.(error)
+		if !ok {
+			t.Fatalf("expected recovered val to be error but was %T", v)
+		}
+		code := mg.ExitStatus(err)
+		// two different error codes returns, so we give up and just use error
+		// code 1.
+		if code != 1 {
+			t.Fatalf("Expected exit status 1, but got %v", code)
+		}
+	}()
+	mg.Deps(f, g)
 }

--- a/mg/errors.go
+++ b/mg/errors.go
@@ -23,7 +23,7 @@ type exitStatus interface {
 // given args and exit with the given exit code.
 func Fatal(code int, args ...interface{}) error {
 	return fatalErr{
-		code:  1,
+		code:  code,
 		error: errors.New(fmt.Sprint(args...)),
 	}
 }
@@ -32,7 +32,21 @@ func Fatal(code int, args ...interface{}) error {
 // given message and exit with an exit code of 1.
 func Fatalf(code int, format string, args ...interface{}) error {
 	return fatalErr{
-		code:  1,
+		code:  code,
 		error: errors.Errorf(format, args...),
 	}
+}
+
+// ExitStatus queries the error for an exit status.  If the error is nil, it
+// returns 0.  If the error does not implement ExitStatus() int, it returns 1.
+// Otherwise it retiurns the value from ExitStatus().
+func ExitStatus(err error) int {
+	if err == nil {
+		return 0
+	}
+	exit, ok := err.(exitStatus)
+	if !ok {
+		return 1
+	}
+	return exit.ExitStatus()
 }

--- a/mg/errors.go
+++ b/mg/errors.go
@@ -1,0 +1,38 @@
+package mg
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type fatalErr struct {
+	code int
+	error
+}
+
+func (f fatalErr) ExitStatus() int {
+	return f.code
+}
+
+type exitStatus interface {
+	ExitStatus() int
+}
+
+// Fatal returns an error that will cause mage to print out the
+// given args and exit with the given exit code.
+func Fatal(code int, args ...interface{}) error {
+	return fatalErr{
+		code:  1,
+		error: errors.New(fmt.Sprint(args...)),
+	}
+}
+
+// Fatalf returns an error that will cause mage to print out the
+// given message and exit with an exit code of 1.
+func Fatalf(code int, format string, args ...interface{}) error {
+	return fatalErr{
+		code:  1,
+		error: errors.Errorf(format, args...),
+	}
+}

--- a/mg/errors_test.go
+++ b/mg/errors_test.go
@@ -1,0 +1,19 @@
+package mg
+
+import "testing"
+
+func TestFatalExit(t *testing.T) {
+	expected := 99
+	code := ExitStatus(Fatal(expected))
+	if code != expected {
+		t.Fatalf("Expected code %v but got %v", expected, code)
+	}
+}
+
+func TestFatalfExit(t *testing.T) {
+	expected := 99
+	code := ExitStatus(Fatalf(expected, "boo!"))
+	if code != expected {
+		t.Fatalf("Expected code %v but got %v", expected, code)
+	}
+}


### PR DESCRIPTION
This removes the use of sync.Map which was not truly necessary
and made the mg package only usable if you had go 1.9.  Also
added a couple error producing functions that make it easier 
to return specific error codes that mage understands.