### PR TITLE
Fix mg package not getting compiled

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/magefile/mage/mage"
+import (
+	"github.com/magefile/mage/mage"
+	_ "github.com/magefile/mage/mg"
+)
 
 func main() {
 	mage.Main()


### PR DESCRIPTION
Package checking only uses .a files and not source files, so we need to compile package mg when building mage. 

I used an underscore import in the mage main to achive this.