### PR TITLE
hash mainfile template with files

### DIFF
--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1,13 +1,39 @@
 package mage
 
 import (
+	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testmain(m))
+}
+
+func testmain(m *testing.M) int {
+	// ensure we write our temporary binaries to a directory that we'll delete
+	// after running tests.
+	dir := "./testing"
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := os.Setenv(CacheEnv, abs); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	return m.Run()
+}
 
 func TestGoRun(t *testing.T) {
 	c := exec.Command("go", "run", "main.go")
 	c.Dir = "./testdata"
+	c.Env = os.Environ()
 	b, err := c.CombinedOutput()
 	if err != nil {
 		t.Error("error:", err)
@@ -16,5 +42,22 @@ func TestGoRun(t *testing.T) {
 	expected := "stuff\n"
 	if actual != expected {
 		t.Fatalf("expected %q, but got %q", expected, actual)
+	}
+}
+
+// ensure we include the hash of the mainfile template in determining the
+// executable name to run, so we automatically create a new exe if the template
+// changes.
+func TestHashTemplate(t *testing.T) {
+	templ := tpl
+	defer func() { tpl = templ }()
+	name, err := ExeName([]string{"./testdata/func.go", "./testdata/command.go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tpl = "some other template"
+	changed, err := ExeName([]string{"./testdata/func.go", "./testdata/command.go"})
+	if changed == name {
+		t.Fatal("expected executable name to chage if template changed")
 	}
 }

--- a/mage/template.go
+++ b/mage/template.go
@@ -1,6 +1,7 @@
 package mage
 
-const tpl = `// +build ignore
+// var only for tests
+var tpl = `// +build ignore
 
 package main
 


### PR DESCRIPTION
This change adds the mainfile template to the list of things we
hash to create the compiled binary name.  This ensures that we
don't have to remember to bump the mageVer when we change the
template, it'll just always auto-update.  mageVer only needs
to change if there's processing that will produce different output
from the template without the template actually changing