### PR TITLE
Added -keep flag for mage intermediate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Options:
   -h    show this help
   -init
         create a starting template if no mage files exist
+  -keep
+        keep intermediate mage files around after running
   -l    list mage targets in this directory
   -v    show verbose output when running mage targets
 ```

--- a/mage/main.go
+++ b/mage/main.go
@@ -155,7 +155,7 @@ func compile(out string, info *parse.PkgInfo, gofiles []string) error {
 	if err != nil {
 		return errors.WithMessage(err, "can't create mainfile")
 	}
-	if keep == false {
+	if !keep {
 		defer os.Remove(mainfile)
 	}
 	defer f.Close()

--- a/mage/main.go
+++ b/mage/main.go
@@ -34,8 +34,8 @@ const mainfile = "mage_output_file.go"
 const initFile = "magefile.go"
 
 var (
-	force, verbose, list, help, mageInit bool
-	tags                                 string
+	force, verbose, list, help, mageInit, keep bool
+	tags                                       string
 )
 
 func init() {
@@ -44,6 +44,7 @@ func init() {
 	flag.BoolVar(&list, "l", false, "list mage targets in this directory")
 	flag.BoolVar(&help, "h", false, "show this help")
 	flag.BoolVar(&mageInit, "init", false, "create a starting template if no mage files exist")
+	flag.BoolVar(&keep, "keep", false, "keep intermediate mage files around after running")
 	flag.Usage = func() {
 		fmt.Println("mage [options] [target]")
 		fmt.Println("Options:")
@@ -154,7 +155,9 @@ func compile(out string, info *parse.PkgInfo, gofiles []string) error {
 	if err != nil {
 		return errors.WithMessage(err, "can't create mainfile")
 	}
-	defer os.Remove(mainfile)
+	if keep == false {
+		defer os.Remove(mainfile)
+	}
 	defer f.Close()
 
 	data := data{

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1,6 +1,7 @@
 package mage
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -60,4 +61,22 @@ func TestHashTemplate(t *testing.T) {
 	if changed == name {
 		t.Fatal("expected executable name to chage if template changed")
 	}
+}
+
+// Test if the -keep flag does keep the mainfile around after running
+func TestKeepFlag(t *testing.T) {
+	buildFile := fmt.Sprintf("./testdata/keep_flag/%s", mainfile)
+	os.Remove(buildFile)
+	c := exec.Command("go", "run", "main.go", "-keep")
+	c.Dir = "./testdata/keep_flag"
+	c.Env = os.Environ()
+	_, err := c.CombinedOutput()
+	if err != nil {
+		t.Error("error:", err)
+	}
+
+	if _, err := os.Stat(fmt.Sprintf(buildFile)); os.IsNotExist(err) {
+		t.Fatalf("expected file %q to exist but it did not", buildFile)
+	}
+	os.Remove(buildFile)
 }

--- a/mage/testdata/keep_flag/.gitignore
+++ b/mage/testdata/keep_flag/.gitignore
@@ -1,0 +1,1 @@
+mage_output_file.go

--- a/mage/testdata/keep_flag/magefile.go
+++ b/mage/testdata/keep_flag/magefile.go
@@ -1,0 +1,15 @@
+// +build mage
+
+package main
+
+import (
+	"fmt"
+)
+
+// This should work as a default - even if it's in a different file
+var Default = Noop
+
+// this should not be a target because it returns a string
+func Noop() {
+	fmt.Println("noop")
+}

--- a/mage/testdata/keep_flag/main.go
+++ b/mage/testdata/keep_flag/main.go
@@ -1,0 +1,13 @@
+// +build ignore
+
+package main
+
+import (
+	"os"
+
+	"github.com/magefile/mage/mage"
+)
+
+func main() {
+	os.Exit(mage.Main())
+}


### PR DESCRIPTION
Added --keep that skips removing the intermediate mage file. 

Readme usage block updated.

closes #14