### PR TITLE
Support multiple targets

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -145,18 +145,32 @@ func Parse(stdout io.Writer, args []string) (inv Invocation, mageInit, showVersi
 			inv.Verbose = envVerbose
 		}
 	}
+	numFlags := 0
+	if inv.Help {
+		numFlags++
+	}
+	if mageInit {
+		numFlags++
+	}
+	if showVersion {
+		numFlags++
+	}
+
+	if numFlags > 1 {
+		return inv, mageInit, showVersion, errors.New("-h, -init, and -version cannot be used simultaneously")
+	}
 
 	inv.Args = fs.Args()
+	if inv.Help && len(inv.Args) > 1 {
+		return inv, mageInit, showVersion, errors.New("-h can only show help for a single target")
+	}
+
 	return inv, mageInit, showVersion, err
 }
 
 // Invoke runs Mage with the given arguments.
 func Invoke(inv Invocation) int {
 	log := log.New(inv.Stderr, "", 0)
-	if len(inv.Args) > 1 {
-		log.Printf("Error: args after the target (%s) are not allowed: %v", inv.Args[0], strings.Join(inv.Args[1:], " "))
-		return 2
-	}
 
 	files, err := Magefiles(inv.Dir)
 	if err != nil {

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -285,24 +285,53 @@ func TestKeepFlag(t *testing.T) {
 	}
 }
 
-func TestStopMultipleTargets(t *testing.T) {
-	stderr := &bytes.Buffer{}
+func TestMultipleTargets(t *testing.T) {
+	var stderr, stdout bytes.Buffer
+	inv := Invocation{
+		Dir:     "./testdata",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+		Args:    []string{"TestVerbose", "ReturnsError"},
+		Verbose: true,
+	}
+	code := Invoke(inv)
+	if code != 0 {
+		t.Errorf("expected 0, but got %v", code)
+	}
+	actual := stderr.String()
+	expected := "Running target: TestVerbose\nhi!\nRunning target: ReturnsError\n"
+	if actual != expected {
+		t.Errorf("expected %q, but got %q", expected, actual)
+	}
+	actual = stdout.String()
+	expected = "stuff\n"
+	if actual != expected {
+		t.Errorf("expected %q, but got %q", expected, actual)
+	}
+}
+
+func TestBadSecondTargets(t *testing.T) {
+	var stderr, stdout bytes.Buffer
 	inv := Invocation{
 		Dir:    "./testdata",
-		Stdout: ioutil.Discard,
-		Stderr: stderr,
-		Args:   []string{"panicserr", "testVerbose"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Args:   []string{"TestVerbose", "NotGonnaWork"},
 	}
 	code := Invoke(inv)
 	if code != 2 {
-		t.Fatalf("expected 1, but got %v", code)
+		t.Errorf("expected 0, but got %v", code)
 	}
 	actual := stderr.String()
-	expected := "Error: args after the target (panicserr) are not allowed: testVerbose\n"
+	expected := "Unknown target specified: NotGonnaWork\n"
 	if actual != expected {
-		t.Fatalf("expected %q, but got %q", expected, actual)
+		t.Errorf("expected %q, but got %q", expected, actual)
 	}
-
+	actual = stdout.String()
+	expected = ""
+	if actual != expected {
+		t.Errorf("expected %q, but got %q", expected, actual)
+	}
 }
 
 func TestParse(t *testing.T) {

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -112,7 +112,7 @@ func TestVerboseEnv(t *testing.T) {
 func TestList(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	inv := Invocation{
-		Dir:    "./testdata",
+		Dir:    "./testdata/list",
 		Stdout: stdout,
 		Stderr: ioutil.Discard,
 		List:   true,
@@ -123,23 +123,19 @@ func TestList(t *testing.T) {
 		t.Errorf("expected to exit with code 0, but got %v", code)
 	}
 	actual := stdout.String()
-	expecteds := []string{
-		"Targets:",
-		"copyStdin",
-		"panics                Function that panics.",
-		"panicsErr             Error function that panics.",
-		`returnsError*         Synopsis for "returns" error.`,
-		"returnsNonNilError    Returns a non-nil error.",
-		"returnsVoid",
-		"testVerbose",
-		"* default target",
-	}
-	for _, expected := range expecteds {
-		if strings.Contains(actual, expected) == false {
-			t.Fatalf("expected:\n%s\n\nto be in:\n%s", expected, actual)
-		}
-	}
+	expected := `
+Targets:
+  somePig*       This is the synopsis for SomePig.
+  testVerbose    
 
+* default target
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
 }
 
 func TestNoArgNoDefaultList(t *testing.T) {

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -128,7 +128,7 @@ func TestList(t *testing.T) {
 		"copyStdin",
 		"panics                Function that panics.",
 		"panicsErr             Error function that panics.",
-		"returnsError*         Synopsis for returns error.",
+		`returnsError*         Synopsis for "returns" error.`,
 		"returnsNonNilError    Returns a non-nil error.",
 		"returnsVoid",
 		"testVerbose",

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -291,7 +291,7 @@ func TestMultipleTargets(t *testing.T) {
 		Dir:     "./testdata",
 		Stdout:  &stdout,
 		Stderr:  &stderr,
-		Args:    []string{"TestVerbose", "ReturnsError"},
+		Args:    []string{"TestVerbose", "ReturnsNilError"},
 		Verbose: true,
 	}
 	code := Invoke(inv)
@@ -299,12 +299,37 @@ func TestMultipleTargets(t *testing.T) {
 		t.Errorf("expected 0, but got %v", code)
 	}
 	actual := stderr.String()
-	expected := "Running target: TestVerbose\nhi!\nRunning target: ReturnsError\n"
+	expected := "Running target: TestVerbose\nhi!\nRunning target: ReturnsNilError\n"
 	if actual != expected {
 		t.Errorf("expected %q, but got %q", expected, actual)
 	}
 	actual = stdout.String()
 	expected = "stuff\n"
+	if actual != expected {
+		t.Errorf("expected %q, but got %q", expected, actual)
+	}
+}
+
+func TestFirstTargetFails(t *testing.T) {
+	var stderr, stdout bytes.Buffer
+	inv := Invocation{
+		Dir:     "./testdata",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+		Args:    []string{"ReturnsNonNilError", "ReturnsNilError"},
+		Verbose: true,
+	}
+	code := Invoke(inv)
+	if code != 1 {
+		t.Errorf("expected 1, but got %v", code)
+	}
+	actual := stderr.String()
+	expected := "Running target: ReturnsNonNilError\nError: bang!\n"
+	if actual != expected {
+		t.Errorf("expected %q, but got %q", expected, actual)
+	}
+	actual = stdout.String()
+	expected = ""
 	if actual != expected {
 		t.Errorf("expected %q, but got %q", expected, actual)
 	}

--- a/mage/testdata/command.go
+++ b/mage/testdata/command.go
@@ -10,7 +10,7 @@ import (
 )
 
 // This should work as a default - even if it's in a different file
-var Default = ReturnsError
+var Default = ReturnsNilError
 
 // this should not be a target because it returns a string
 func ReturnsString() string {

--- a/mage/testdata/func.go
+++ b/mage/testdata/func.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-// Synopsis for returns error.
+// Synopsis for "returns" error.
 // And some more text.
 func ReturnsError() error {
 	fmt.Println("stuff")

--- a/mage/testdata/func.go
+++ b/mage/testdata/func.go
@@ -10,7 +10,7 @@ import (
 
 // Synopsis for "returns" error.
 // And some more text.
-func ReturnsError() error {
+func ReturnsNilError() error {
 	fmt.Println("stuff")
 	return nil
 }

--- a/mage/testdata/list/command.go
+++ b/mage/testdata/list/command.go
@@ -1,0 +1,29 @@
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/magefile/mage/mg"
+)
+
+var Default = SomePig
+
+// this should not be a target because it returns a string
+func ReturnsString() string {
+	fmt.Println("more stuff")
+	return ""
+}
+
+func TestVerbose() {
+	log.Println("hi!")
+}
+
+// This is the synopsis for SomePig.  There's more data that won't show up.
+func SomePig() {
+	mg.Deps(f)
+}
+
+func f() {}

--- a/magefile.go
+++ b/magefile.go
@@ -12,8 +12,7 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// Runs "go install" for mage.  This generates the version
-// info the binary.
+// Runs "go install" for mage.  This generates the version info the binary.
 func Build() error {
 	ldf, err := flags()
 	if err != nil {
@@ -43,6 +42,11 @@ func Release() (err error) {
 		}
 	}()
 	return sh.RunV("goreleaser")
+}
+
+// Remove the temporarily generated files from Release.
+func Clean() error {
+	return sh.Rm("dist")
 }
 
 func flags() (string, error) {

--- a/magefile.go
+++ b/magefile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// Runs go install for mage.  This generates the the version
+// Runs "go install" for mage.  This generates the version
 // info the binary.
 func Build() error {
 	ldf, err := flags()

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -39,36 +39,32 @@ type Function struct {
 func (f Function) TemplateString() string {
 	if f.IsContext && f.IsError {
 		out := `wrapFn := func(ctx context.Context) error {
-			return %s(ctx)
-		}
-		err := runTarget(wrapFn)
-		`
+				return %s(ctx)
+			}
+			err := runTarget(wrapFn)`
 		return fmt.Sprintf(out, f.Name)
 	}
 	if f.IsContext && !f.IsError {
 		out := `wrapFn := func(ctx context.Context) error {
-			%s(ctx)
-			return nil
-		}
-		err := runTarget(wrapFn)
-		`
+				%s(ctx)
+				return nil
+			}
+			err := runTarget(wrapFn)`
 		return fmt.Sprintf(out, f.Name)
 	}
 	if !f.IsContext && f.IsError {
 		out := `wrapFn := func(ctx context.Context) error {
-			return %s()
-		}
-		err := runTarget(wrapFn)
-		`
+				return %s()
+			}
+			err := runTarget(wrapFn)`
 		return fmt.Sprintf(out, f.Name)
 	}
 	if !f.IsContext && !f.IsError {
 		out := `wrapFn := func(ctx context.Context) error {
-			%s()
-			return nil
-		}
-		err := runTarget(wrapFn)
-		`
+				%s()
+				return nil
+			}
+			err := runTarget(wrapFn)`
 		return fmt.Sprintf(out, f.Name)
 	}
 	return `fmt.Printf("Error formatting job code\n")

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -13,7 +13,7 @@ func TestParse(t *testing.T) {
 
 	expected := []Function{
 		{
-			Name:     "ReturnsError",
+			Name:     "ReturnsNilError",
 			IsError:  true,
 			Comment:  "Synopsis for \"returns\" error.\nAnd some more text.\n",
 			Synopsis: `Synopsis for "returns" error.`,
@@ -39,8 +39,8 @@ func TestParse(t *testing.T) {
 	}
 
 	// DefaultName
-	if info.DefaultName != "ReturnsError" {
-		t.Fatalf("expected DefaultName to be ReturnsError")
+	if info.DefaultName != "ReturnsNilError" {
+		t.Fatalf("expected DefaultName to be ReturnsNilError")
 	}
 
 	for _, fn := range expected {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -15,8 +15,8 @@ func TestParse(t *testing.T) {
 		{
 			Name:     "ReturnsError",
 			IsError:  true,
-			Comment:  "Synopsis for returns error.\nAnd some more text.\n",
-			Synopsis: "Synopsis for returns error.",
+			Comment:  "Synopsis for \"returns\" error.\nAnd some more text.\n",
+			Synopsis: `Synopsis for "returns" error.`,
 		},
 		{
 			Name: "ReturnsVoid",

--- a/parse/testdata/command.go
+++ b/parse/testdata/command.go
@@ -5,11 +5,12 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/magefile/mage/mg"
 )
 
 // This should work as a default - even if it's in a different file
-var Default = ReturnsError
+var Default = ReturnsNilError
 
 // this should not be a target because it returns a string
 func ReturnsString() string {

--- a/parse/testdata/func.go
+++ b/parse/testdata/func.go
@@ -6,7 +6,7 @@ import "fmt"
 
 // Synopsis for "returns" error.
 // And some more text.
-func ReturnsError() error {
+func ReturnsNilError() error {
 	fmt.Println("stuff")
 	return nil
 }

--- a/parse/testdata/func.go
+++ b/parse/testdata/func.go
@@ -4,7 +4,7 @@ package main
 
 import "fmt"
 
-// Synopsis for returns error.
+// Synopsis for "returns" error.
 // And some more text.
 func ReturnsError() error {
 	fmt.Println("stuff")

--- a/site/content/targets/_index.en.md
+++ b/site/content/targets/_index.en.md
@@ -20,6 +20,11 @@ A target may be designated the default target, which is run when the user runs
 <targetname>`  If no default target is specified, running `mage` with no target
 will print the list of targets, like `mage -l`.
 
-Currently only a single target may be run at a single time.  Attempting to run
-multiple targets from a single invocation of mage will result in an error.  This
-may change in the future.
+## Multiple Targets
+
+Multiple targets can be specified as args to Mage, for example `mage foo bar
+baz`.  Targets will be run serially, from left to right (so in thise case, foo,
+then once foo is done, bar, then once bar is done, baz).  Dependencies run using
+mg.Deps will still only run once per mage execution, so if each of the targets
+depend on the same function, that function will only be run once for all
+targets.

--- a/site/content/targets/_index.en.md
+++ b/site/content/targets/_index.en.md
@@ -27,4 +27,4 @@ baz`.  Targets will be run serially, from left to right (so in thise case, foo,
 then once foo is done, bar, then once bar is done, baz).  Dependencies run using
 mg.Deps will still only run once per mage execution, so if each of the targets
 depend on the same function, that function will only be run once for all
-targets.
+targets.  If any target panics or returns an error, no later targets will be run.


### PR DESCRIPTION
closes #34 

You may now specify multiple mage targets on the cli, e.g. `mage build clean`.  