### PR TITLE
website: typo on dependencies page. g should depend on h, not on itself

### DIFF
--- a/site/content/dependencies/_index.en.md
+++ b/site/content/dependencies/_index.en.md
@@ -29,7 +29,7 @@ func f() {
 }
 
 func g() {
-    mg.Deps(g)
+    mg.Deps(h)
     fmt.Println("g running")
 }
 


### PR DESCRIPTION
I believe there's a typo on https://magefile.org/dependencies/. Currently, `g` depends on itself but it looks like it should have depended on `h` instead.