### PR TITLE
Fix various typos

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -204,7 +204,7 @@ func makeInfo(dir string, fset *token.FileSet, files map[string]*ast.File) (type
 }
 
 // errorOrVoid filters the list of functions to only those that return only an
-// error or have no return value, and have no paramters.
+// error or have no return value, and have no parameters.
 func errorOrVoid(fns []*ast.FuncDecl, info types.Info) []*ast.FuncDecl {
 	fds := []*ast.FuncDecl{}
 

--- a/site/content/howitworks/_index.en.md
+++ b/site/content/howitworks/_index.en.md
@@ -20,4 +20,4 @@ customized by setting the MAGEFILE_CACHE environment variable.
 
 Mage itself requires no dependencies to run. However, because it is compiling
 go code, you must have a valid go environment set up on your machine.  Mage is
-compatibile with any go 1.x environment.
+compatible with any go 1.x environment.

--- a/site/themes/learn/exampleSite/content/basics/installation/_index.en.md
+++ b/site/themes/learn/exampleSite/content/basics/installation/_index.en.md
@@ -36,7 +36,7 @@ home = [ "HTML", "RSS", "JSON"]
 
 ## Create your first chapter page
 
-Chapters are pages containg other child pages. It has a special layout style and usually just contains a _chapter name_, the _title_ and a _brief abstract_ of the section.
+Chapters are pages containing other child pages. It has a special layout style and usually just contains a _chapter name_, the _title_ and a _brief abstract_ of the section.
 
 ```
 ### Chapter 1

--- a/site/themes/learn/exampleSite/content/cont/menushortcuts.en.md
+++ b/site/themes/learn/exampleSite/content/cont/menushortcuts.en.md
@@ -35,7 +35,7 @@ Example from the current website:
     weight = 30
 
 By default, shortcuts are preceded by a title. This title can be disabled by setting `disableShortcutsTitle=true`. 
-However, if you want to keep the title but change its value, it can be overriden by changing your local i18n translation string configuration. 
+However, if you want to keep the title but change its value, it can be overridden by changing your local i18n translation string configuration. 
 
 For example, in your local `i18n/en.toml` file, add the following content
 


### PR DESCRIPTION
Small fix for some typos found by running [misspell ](https://github.com/client9/misspell) on your source.