### PR TITLE
Fixed backward compatibility

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -40,8 +40,11 @@ var initOutput = template.Must(template.New("").Parse(mageTpl))
 const mainfile = "mage_output_file.go"
 const initFile = "magefile.go"
 
+// set by ldflags when you "mage build"
 var (
-	timestamp, commitHash, gitTag string // set by ldflags when you "mage build"
+	commitHash string
+	timestamp  string
+	gitTag     = "v2"
 )
 
 // Main is the entrypoint for running mage.  It exists external to mage's main

--- a/mage/testdata/onlyStdLib/command.go
+++ b/mage/testdata/onlyStdLib/command.go
@@ -1,0 +1,29 @@
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/magefile/mage/mg"
+)
+
+var Default = SomePig
+
+// this should not be a target because it returns a string
+func ReturnsString() string {
+	fmt.Println("more stuff")
+	return ""
+}
+
+func TestVerbose() {
+	log.Println("hi!")
+}
+
+// This is the synopsis for SomePig.  There's more data that won't show up.
+func SomePig() {
+	mg.Deps(f)
+}
+
+func f() {}

--- a/mg/deps.go
+++ b/mg/deps.go
@@ -36,7 +36,7 @@ var onces = &onceMap{
 // shouldn't be run at the same time.
 func SerialDeps(fns ...interface{}) {
 	checkFns(fns)
-	ctx, _ := Context()
+	ctx := context.Background()
 	for _, f := range fns {
 		runDeps(ctx, f)
 	}
@@ -115,8 +115,7 @@ func checkFns(fns []interface{}) {
 
 // Deps runs the given functions with the default runtime context
 func Deps(fns ...interface{}) {
-	ctx, _ := Context()
-	CtxDeps(ctx, fns...)
+	CtxDeps(context.Background(), fns...)
 }
 
 func changeExit(old, new int) int {

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -1,12 +1,9 @@
 package mg
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
-	"time"
 )
 
 // CacheEnv is the environment variable that users may set to change the
@@ -36,27 +33,4 @@ func CacheDir() string {
 	default:
 		return filepath.Join(os.Getenv("HOME"), ".magefile")
 	}
-}
-
-var ctx context.Context
-var ctxCancel func()
-
-func Context() (context.Context, func()) {
-	if ctx != nil {
-		return ctx, ctxCancel
-	}
-
-	if os.Getenv("MAGEFILE_TIMEOUT") != "" {
-		timeout, err := time.ParseDuration(os.Getenv("MAGEFILE_TIMEOUT"))
-		if err != nil {
-			fmt.Printf("timeout error: %v\n", err)
-			os.Exit(1)
-		}
-
-		ctx, ctxCancel = context.WithTimeout(context.Background(), timeout)
-	} else {
-		ctx = context.Background()
-		ctxCancel = func() {}
-	}
-	return ctx, ctxCancel
 }

--- a/site/content/magefiles/_index.en.md
+++ b/site/content/magefiles/_index.en.md
@@ -61,7 +61,7 @@ var Default = Install
 
 // Targets may have a context argument, in which case a default context is passed
 // to the target, which will be cancelled after a timeout if the -t flag is used.
-func Build(ctx context.Context) error {
+func Build(ctx context.Context) {
     mg.CtxDeps(ctx, Target)
 }
 

--- a/site/content/targets/_index.en.md
+++ b/site/content/targets/_index.en.md
@@ -38,5 +38,13 @@ targets.  If any target panics or returns an error, no later targets will be run
 ## Contexts and Cancellation
 
 A default context is passed into any target with a context argument.  This
-context will have a timeout if mage was run with -t, and thus will cancel
-the running targets and dependencies at that time.
+context will have a timeout if mage was run with -t, and thus will cancel the
+running targets and dependencies at that time.  To pass this context to
+dependencies, use mg.CtxDeps(ctx, ...) to pass the context from the target to
+its dependencies (and pass the context to sub-dependencies).  Dependencies run
+with mg.Deps will not get the starting context, and thus will not be cancelled
+when the timeout set with -t expires.
+
+mg.CtxDeps will pass along whatever context you give it, so if you want to
+modify the original context, or pass in your own, that will work like you expect
+it to.


### PR DESCRIPTION
This PR removes the use of mg.Context from the generated mainfile,
instead generating the code to create the context in the mainfile
itself. This prevents backwards compatibility problems with older
versions of mage that may be vendored, which don't have mg.Context.

Also adds a test to ensure that we don't have the generated mainfile
depend on anything outside the stdlib.