### PR TITLE
Enable bootstrap build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,16 @@ or other trivial change.
 
 ## Dependency Management
 
-Currently mage has no dependencies(!).  Let's try to keep it that way.  Since
-it's likely that mage will be vendored into a project, adding dependencies to
-mage adds dependencies to every project that uses mage.
+Currently mage has no dependencies(!) outside the standard libary.  Let's keep
+it that way.  Since it's likely that mage will be vendored into a project,
+adding dependencies to mage adds dependencies to every project that uses mage.
 
 ## Versions
 
-Please try to avoid using features of go and the stdlib that prevent mage from
-being buildable with old versions of Go.  Definitely avoid anything that
-requires go 1.9.
+Please avoid using features of go and the stdlib that prevent mage from being
+buildable with older versions of Go.  The CI tests currently check that mage is
+buildable with go 1.7 and later.  You may build with whatever version you like,
+but CI has the final say.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,28 @@
 ## About [![Build Status](https://travis-ci.org/magefile/mage.svg?branch=master)](https://travis-ci.org/magefile/mage)
 
 Mage is a make/rake-like build tool using Go.  You write plain-old go functions,
-and mage automatically uses them as Makefile-like runnable targets.
-
+and Mage automatically uses them as Makefile-like runnable targets.
 
 ## Installation
 
-Install by running `go run bootstrap.go`, which will build the mage binary with
-compile-time data on the version number and commit hash.  If you have installed
-using `go get`, your binary will work just fine, but will not have the version
-number or commit hash. To fix this, just run `mage build` in the root of the
-mage repo (or run `go run bootstrap.go`).
+Mage has no dependencies outside the Go standard library, and builds with Go 1.7
+and above (possibly even lower versions, but they're not regularly tested). 
+
+Install mage by running 
+
+```
+go get -u -d github.com/magefile/mage
+cd $GOPATH/src/github.com/magefile/mage
+go run bootstrap.go
+```
+
+This will download the code into your GOPATH, and then run the bootstrap script
+to build mage with version infomation embedded in it.  A normal `go get`
+(without -d) will build the binary correctly, but no version info will be
+embedded.  If you've done this, no worries, just go to
+$GOPATH/src/github.com/magefile/mage and run `mage build` or `go run
+bootstrap.go` and a new binary will be created with the correct version
+information.
 
 The mage binary will be created in your $GOPATH/bin directory.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 <h1 align=center>mage</h1>
 <p align="center"><img src="https://user-images.githubusercontent.com/3185864/31061203-6f6743dc-a6ec-11e7-9469-b8d667d9bc3f.png"/></p>
 
-<p align="center">Mage is a make/rake-like build tool using Go.</p>
+## About [![Build Status](https://travis-ci.org/magefile/mage.svg?branch=master)](https://travis-ci.org/magefile/mage)
 
-[![Build Status](https://travis-ci.org/magefile/mage.svg?branch=master)](https://travis-ci.org/magefile/mage)
+Mage is a make/rake-like build tool using Go.  You write plain-old go functions,
+and mage automatically uses them as Makefile-like runnable targets.
+
+
+## Installation
+
+Install by running `go run bootstrap.go`, which will build the mage binary with
+compile-time data on the version number and commit hash.  If you have installed
+using `go get`, your binary will work just fine, but will not have the version
+number or commit hash. To fix this, just run `mage build` in the root of the
+mage repo (or run `go run bootstrap.go`).
+
+The mage binary will be created in your $GOPATH/bin directory.
+
+You may also install a binary release from our
+[releases](https://github.com/magefile/mage/releases) page. 
 
 ## Demo
 

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,0 +1,19 @@
+//+build ignore
+
+package main
+
+import (
+	"os"
+
+	"github.com/magefile/mage/mage"
+)
+
+// This is a bootstrap builder, to build mage when you don't already *have* mage.
+// Run it like
+// go run bootstrap.go
+// and it will install mage with all the right flags created for you.
+
+func main() {
+	os.Args = []string{os.Args[0], "-v", "build"}
+	os.Exit(mage.Main())
+}

--- a/mage/main.go
+++ b/mage/main.go
@@ -24,9 +24,11 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// mageVer is used when hashing the output binary to ensure that we get a new
-// binary if we use a differernt version of mage.
-const mageVer = "v0.3"
+// magicRebuildKey is used when hashing the output binary to ensure that we get
+// a new binary even if nothing in the input files or generated mainfile has
+// changed. This can be used when we change how we parse files, or otherwise
+// change the inputs to the compiling process.
+const magicRebuildKey = "v0.3"
 
 var output = template.Must(template.New("").Funcs(map[string]interface{}{
 	"lower": strings.ToLower,
@@ -338,7 +340,7 @@ func ExeName(files []string) (string, error) {
 	// binary.
 	hashes = append(hashes, fmt.Sprintf("%x", sha1.Sum([]byte(tpl))))
 	sort.Strings(hashes)
-	hash := sha1.Sum([]byte(strings.Join(hashes, "") + mageVer))
+	hash := sha1.Sum([]byte(strings.Join(hashes, "") + magicRebuildKey))
 	filename := fmt.Sprintf("%x", hash)
 
 	out := filepath.Join(mg.CacheDir(), filename)

--- a/magefile.go
+++ b/magefile.go
@@ -19,7 +19,10 @@ func Build() error {
 		return err
 	}
 
-	return sh.Run("go", "install", "-ldflags="+ldf, "github.com/magefile/mage")
+	// we use -a here to always reinstall, because if someone built with go get,
+	// then this would turn into a no-op, and they wouldn't get a binary with
+	// the version and commit etc set.
+	return sh.RunV("go", "install", "-a", "-ldflags="+ldf, "github.com/magefile/mage")
 }
 
 // Generates a new release.  Expects the TAG environment variable to be set,

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -4,15 +4,37 @@ title = "Mage"
 
 <p align="center"><img width=300 src="/images/gary.svg"/></p>
 
-<p align="center">Mage is a make/rake-like build tool using Go.</p>
+## About
+
+Mage is a make/rake-like build tool using Go.  You write plain-old go functions,
+and Mage automatically uses them as Makefile-like runnable targets.
+
 
 ## Installation
 
 Mage has no dependencies outside the Go standard library, and builds with Go 1.7
-and above (possibly even lower versions, but they're not regularly tested). To
-install, just use `go get`:
+and above (possibly even lower versions, but they're not regularly tested). 
 
-`go get github.com/magefile/mage`
+Install mage by running 
+
+```
+go get -u -d github.com/magefile/mage
+cd $GOPATH/src/github.com/magefile/mage
+go run bootstrap.go
+```
+
+This will download the code into your GOPATH, and then run the bootstrap script
+to build mage with version infomation embedded in it.  A normal `go get`
+(without -d) will build the binary correctly, but no version info will be
+embedded.  If you've done this, no worries, just go to
+$GOPATH/src/github.com/magefile/mage and run `mage build` or `go run
+bootstrap.go` and a new binary will be created with the correct version
+information.
+
+The mage binary will be created in your $GOPATH/bin directory.
+
+You may also install a binary release from our
+[releases](https://github.com/magefile/mage/releases) page. 
 
 ## Demo
 


### PR DESCRIPTION
Added a bootstrap.go file that can be used with go run to install mage even if you don't
have mage intalled.