### PR TITLE
fix mage install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install: true
 
 # don't call go test -v because we want to be able to only show t.Log output when
 # a test fails
-script:  go test -race $(go list ./... | grep -v /vendor/)
+script:  go test -tags CI -race $(go list ./... | grep -v /vendor/)
 
 # run a test for every major OS
 env:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will download the code into your GOPATH, and then run the bootstrap script
 to build mage with version infomation embedded in it.  A normal `go get`
 (without -d) will build the binary correctly, but no version info will be
 embedded.  If you've done this, no worries, just go to
-$GOPATH/src/github.com/magefile/mage and run `mage build` or `go run
+$GOPATH/src/github.com/magefile/mage and run `mage install` or `go run
 bootstrap.go` and a new binary will be created with the correct version
 information.
 

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -14,6 +14,6 @@ import (
 // and it will install mage with all the right flags created for you.
 
 func main() {
-	os.Args = []string{os.Args[0], "-v", "build"}
+	os.Args = []string{os.Args[0], "-v", "install"}
 	os.Exit(mage.Main())
 }

--- a/install_test.go
+++ b/install_test.go
@@ -1,0 +1,31 @@
+//+build CI
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestBootstrap(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	s, err := run("go", "run", "bootstrap.go")
+	if err != nil {
+		t.Fatal(s)
+	}
+	name := "mage"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	if _, err := os.Stat(filepath.Join(os.Getenv("GOPATH"), "bin", name)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/magefile.go
+++ b/magefile.go
@@ -30,13 +30,19 @@ func Install() error {
 		return fmt.Errorf("can't determine GOPATH: %v", err)
 	}
 	paths := strings.Split(gopath, string([]rune{os.PathListSeparator}))
-	bin := filepath.Join(paths[0], "bin", name)
+	bin := filepath.Join(paths[0], "bin")
+	// specifically don't mkdirall, if you have an invalid gopath in the first
+	// place, that's not on us to fix.
+	if err := os.Mkdir(bin, 0700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to create %q: %v", bin, err)
+	}
+	path := filepath.Join(bin, name)
 
 	// we use go build here because if someone built with go get, then `go
 	// install` turns into a no-op, and `go install -a` fails on people's
 	// machines that have go installed in a non-writeable directory (such as
 	// normal OS installs in /usr/bin)
-	return sh.RunV("go", "build", "-o", bin, "-ldflags="+ldf, "github.com/magefile/mage")
+	return sh.RunV("go", "build", "-o", path, "-ldflags="+ldf, "github.com/magefile/mage")
 }
 
 // Generates a new release.  Expects the TAG environment variable to be set,

--- a/magefile.go
+++ b/magefile.go
@@ -3,26 +3,40 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/magefile/mage/sh"
 )
 
 // Runs "go install" for mage.  This generates the version info the binary.
-func Build() error {
+func Install() error {
 	ldf, err := flags()
 	if err != nil {
 		return err
 	}
 
-	// we use -a here to always reinstall, because if someone built with go get,
-	// then this would turn into a no-op, and they wouldn't get a binary with
-	// the version and commit etc set.
-	return sh.RunV("go", "install", "-a", "-ldflags="+ldf, "github.com/magefile/mage")
+	name := "mage"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	gopath, err := sh.Output("go", "env", "GOPATH")
+	if err != nil {
+		return fmt.Errorf("can't determine GOPATH: %v", err)
+	}
+	paths := strings.Split(gopath, string([]rune{os.PathListSeparator}))
+	bin := filepath.Join(paths[0], "bin", name)
+
+	// we use go build here because if someone built with go get, then `go
+	// install` turns into a no-op, and `go install -a` fails on people's
+	// machines that have go installed in a non-writeable directory (such as
+	// normal OS installs in /usr/bin)
+	return sh.RunV("go", "build", "-o", bin, "-ldflags="+ldf, "github.com/magefile/mage")
 }
 
 // Generates a new release.  Expects the TAG environment variable to be set,
@@ -63,9 +77,8 @@ func flags() (string, error) {
 
 // tag returns the git tag for the current branch or "" if none.
 func tag() string {
-	buf := &bytes.Buffer{}
-	_, _ = sh.Exec(nil, buf, nil, "git", "describe", "--tags")
-	return buf.String()
+	s, _ := sh.Output("git", "describe", "--tags")
+	return s
 }
 
 // hash returns the git hash for the current repo or "" if none.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -25,7 +25,7 @@ This will download the code into your GOPATH, and then run the bootstrap script
 to build mage with version infomation embedded in it.  A normal `go get`
 (without -d) will build the binary correctly, but no version info will be
 embedded.  If you've done this, no worries, just go to
-$GOPATH/src/github.com/magefile/mage and run `mage build` or `go run
+$GOPATH/src/github.com/magefile/mage and run `mage install` or `go run
 bootstrap.go` and a new binary will be created with the correct version
 information.
 


### PR DESCRIPTION
Go install -a can fail if goroot is not writeable, so use go build instead.

fixes #88 