### PR TITLE
Avoid name conflicts with magefiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,3 @@ install: true
 # don't call go test -v because we want to be able to only show t.Log output when
 # a test fails
 script:  go test -tags CI -race $(go list ./... | grep -v /vendor/)
-
-# run a test for every major OS
-env:
-  - GOOS=linux
-  - GOOS=windows
-  - GOOS=darwin
-  


### PR DESCRIPTION
Previously, the generated mage_output_file contained a few helper functions and variables.
However, these had the potential to conflict with names of things in someone's magefile.
Now, all those names are safely stowed away inside func main, so there can be no conflict.