### PR TITLE
parse: sanitize function doc synopsis

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	info, err := Package("./testdata", []string{"func.go", "command.go", "alias.go"})
+	info, err := Package("./testdata", []string{"func.go", "command.go", "alias.go", "repeating_synopsis.go"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +30,12 @@ func TestParse(t *testing.T) {
 			Name:      "TakesContextReturnsVoid",
 			IsError:   false,
 			IsContext: true,
+		},
+		{
+			Name:     "RepeatingSynopsis",
+			IsError:  true,
+			Comment:  "RepeatingSynopsis chops off the repeating function name.\nSome more text.\n",
+			Synopsis: "chops off the repeating function name.",
 		},
 	}
 

--- a/parse/testdata/repeating_synopsis.go
+++ b/parse/testdata/repeating_synopsis.go
@@ -1,0 +1,9 @@
+// +build mage
+
+package main
+
+// RepeatingSynopsis chops off the repeating function name.
+// Some more text.
+func RepeatingSynopsis() error {
+	return nil
+}


### PR DESCRIPTION
This change adds `sanitizeSynopsis()` function to perform basic
sanitization on the synopsis. If synopsis begins with the function name, it
removes the function to avoid repeating words.

Sorry if I've added too many comments trying to leave hints for the particular piece of code. I can remove them if they are silly 😅

Fixes #50 