### PR TITLE
Add alternative way of adding alias.

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -66,3 +66,32 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+func TestScanAlias(t *testing.T) {
+	table := []struct {
+		doc   string
+		alias []string
+	}{
+		{
+			"", nil,
+		},
+		{
+			"alias:a", []string{"a"},
+		},
+		{
+			"alias: a", []string{"a"},
+		},
+		{
+			"alias: a this is an alias", []string{"a"},
+		},
+		{
+			"alias: a this is an alias \n alias: b", []string{"a", "b"},
+		},
+	}
+	for _, v := range table {
+		a := scanAlias(v.doc)
+		if !reflect.DeepEqual(a, v.alias) {
+			t.Errorf("expected %v got %v", v.alias, a)
+		}
+	}
+}


### PR DESCRIPTION
Any word following  alias: in a comment on a mage target is  an alias.

example

```go
//+build mage

package main

import (
	"fmt"
)

// prints hello,word on stdout
// alias: hello
func helloWorld() {
	return fmt.Println("hello, world")
}
```

This will register hello as an alias to helloWorld target.