### PR TITLE
Add `-compile` flag to compile a static binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ mage_output_file.go
 
 # stupid osx
 .DS_Store
+
+# Goland
+.idea
+*.iml

--- a/mage/command_string.go
+++ b/mage/command_string.go
@@ -2,15 +2,15 @@
 
 package mage
 
-import "fmt"
+import "strconv"
 
-const _Command_name = "NoneVersionInitClean"
+const _Command_name = "NoneVersionInitCleanCompileStatic"
 
-var _Command_index = [...]uint8{0, 4, 11, 15, 20}
+var _Command_index = [...]uint8{0, 4, 11, 15, 20, 33}
 
 func (i Command) String() string {
 	if i < 0 || i >= Command(len(_Command_index)-1) {
-		return fmt.Sprintf("Command(%d)", i)
+		return "Command(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Command_name[_Command_index[i]:_Command_index[i+1]]
 }

--- a/mage/main.go
+++ b/mage/main.go
@@ -185,6 +185,7 @@ func Parse(stdout io.Writer, args []string) (inv Invocation, cmd Command, err er
 		numFlags++
 		cmd = CompileStatic
 		inv.CompileOut = compileOutPath
+		inv.Force = true
 	case showVersion:
 		numFlags++
 		cmd = Version

--- a/mage/main.go
+++ b/mage/main.go
@@ -56,10 +56,11 @@ var (
 type Command int
 
 const (
-	None    Command = iota
-	Version         // report the current version of mage
-	Init            // create a starting template for mage
-	Clean           // clean out old compiled mage binaries from the cache
+	None          Command = iota
+	Version               // report the current version of mage
+	Init                  // create a starting template for mage
+	Clean                 // clean out old compiled mage binaries from the cache
+	CompileStatic         // compile a static binary of the current directory
 )
 
 // Main is the entrypoint for running mage.  It exists external to mage's main
@@ -71,17 +72,18 @@ func Main() int {
 
 // Invocation contains the args for invoking a run of Mage.
 type Invocation struct {
-	Dir     string        // directory to read magefiles from
-	Force   bool          // forces recreation of the compiled binary
-	Verbose bool          // tells the magefile to print out log statements
-	List    bool          // tells the magefile to print out a list of targets
-	Help    bool          // tells the magefile to print out help for a specific target
-	Keep    bool          // tells mage to keep the generated main file after compiling
-	Timeout time.Duration // tells mage to set a timeout to running the targets
-	Stdout  io.Writer     // writer to write stdout messages to
-	Stderr  io.Writer     // writer to write stderr messages to
-	Stdin   io.Reader     // reader to read stdin from
-	Args    []string      // args to pass to the compiled binary
+	Dir        string        // directory to read magefiles from
+	Force      bool          // forces recreation of the compiled binary
+	Verbose    bool          // tells the magefile to print out log statements
+	List       bool          // tells the magefile to print out a list of targets
+	Help       bool          // tells the magefile to print out help for a specific target
+	Keep       bool          // tells mage to keep the generated main file after compiling
+	Timeout    time.Duration // tells mage to set a timeout to running the targets
+	CompileOut string        // tells mage to compile a static binary to this path, but not execute
+	Stdout     io.Writer     // writer to write stdout messages to
+	Stderr     io.Writer     // writer to write stderr messages to
+	Stdin      io.Reader     // reader to read stdin from
+	Args       []string      // args to pass to the compiled binary
 }
 
 // ParseAndRun parses the command line, and then compiles and runs the mage
@@ -128,6 +130,8 @@ func ParseAndRun(dir string, stdout, stderr io.Writer, stdin io.Reader, args []s
 		}
 		log.Println(dir, "cleaned")
 		return 0
+	case CompileStatic:
+		return Invoke(inv)
 	case None:
 		return Invoke(inv)
 	default:
@@ -153,6 +157,8 @@ func Parse(stdout io.Writer, args []string) (inv Invocation, cmd Command, err er
 	fs.BoolVar(&mageInit, "init", false, "create a starting template if no mage files exist")
 	var clean bool
 	fs.BoolVar(&clean, "clean", false, "clean out old generated binaries from CACHE_DIR")
+	var compileOutPath string
+	fs.StringVar(&compileOutPath, "compile", "", "path to which to output a static binary")
 
 	fs.Usage = func() {
 		fmt.Fprintln(stdout, "mage [options] [target]")
@@ -175,6 +181,10 @@ func Parse(stdout io.Writer, args []string) (inv Invocation, cmd Command, err er
 	case mageInit:
 		numFlags++
 		cmd = Init
+	case compileOutPath != "":
+		numFlags++
+		cmd = CompileStatic
+		inv.CompileOut = compileOutPath
 	case showVersion:
 		numFlags++
 		cmd = Version
@@ -183,7 +193,7 @@ func Parse(stdout io.Writer, args []string) (inv Invocation, cmd Command, err er
 		cmd = Clean
 		if fs.NArg() > 0 || fs.NFlag() > 1 {
 			// Temporary dupe of below check until we refactor the other commands to use this check
-			return inv, cmd, errors.New("-h, -init, -clean, and -version cannot be used simultaneously")
+			return inv, cmd, errors.New("-h, -init, -clean, -compile and -version cannot be used simultaneously")
 
 		}
 	}
@@ -201,7 +211,7 @@ func Parse(stdout io.Writer, args []string) (inv Invocation, cmd Command, err er
 	}
 
 	if numFlags > 1 {
-		return inv, cmd, errors.New("-h, -init, -clean, and -version cannot be used simultaneously")
+		return inv, cmd, errors.New("-h, -init, -clean, -compile and -version cannot be used simultaneously")
 	}
 
 	inv.Args = fs.Args()
@@ -228,10 +238,12 @@ func Invoke(inv Invocation) int {
 	}
 
 	exePath, err := ExeName(files)
-
 	if err != nil {
 		log.Println("Error:", err)
 		return 1
+	}
+	if inv.CompileOut != "" {
+		exePath = inv.CompileOut
 	}
 
 	if !inv.Force {
@@ -281,6 +293,10 @@ func Invoke(inv Invocation) int {
 		// compiled file screws things up.  Yes this doubles up with the above
 		// defer, that's ok.
 		os.Remove(main)
+	}
+
+	if inv.CompileOut != "" {
+		return 0
 	}
 
 	return RunCompiled(inv, exePath)

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -53,18 +53,22 @@ plugin.  Every tool you use with Go can be used with Magefiles.
 ```
 mage [options] [target]
 Options:
-  -f    force recreation of compiled magefile
-  -h    show this help
+  -clean
+    	clean out old generated binaries from CACHE_DIR
+  -compile string
+    	path to which to output a static binary
+  -f	force recreation of compiled magefile
+  -h	show this help
   -init
-        create a starting template if no mage files exist
+    	create a starting template if no mage files exist
   -keep
-        keep intermediate mage files around after running
-  -l    list mage targets in this directory
-  -t string
-    	  timeout in duration parsable format (e.g. 5m30s)
-  -v    show verbose output when running mage targets
+    	keep intermediate mage files around after running
+  -l	list mage targets in this directory
+  -t duration
+    	timeout in duration parsable format (e.g. 5m30s)
+  -v	show verbose output when running mage targets
   -version
-        show version info for the mage binary
+    	show version info for the mage binary
 ```
 
 ## Environment Variables
@@ -74,14 +78,27 @@ without having to remember to pass -v every time.
 
 ## Why?
 
-Makefiles are hard to read and hard to write.  Mostly because makefiles are essentially fancy bash scripts with significant white space and additional make-related syntax.
+Makefiles are hard to read and hard to write.  Mostly because makefiles are essentially fancy bash
+scripts with significant white space and additional make-related syntax.
 
-Mage lets you have multiple magefiles, name your magefiles whatever you
-want, and they're easy to customize for multiple operating systems.  Mage has no
-dependencies (aside from go) and runs just fine on all major operating systems, whereas make generally uses bash which is not well supported on Windows.
-Go is superior to bash for any non-trivial task involving branching, looping, anything that's not just straight line execution of commands.  And if your project is written in Go, why introduce another
-language as idiosyncratic as bash?  Why not use the language your contributors
-are already comfortable with?
+Mage lets you have multiple magefiles, name your magefiles whatever you want, and they're easy to
+customize for multiple operating systems.  Mage has no dependencies (aside from go) and runs just
+fine on all major operating systems, whereas make generally uses bash which is not well supported on
+Windows.  Go is superior to bash for any non-trivial task involving branching, looping, anything
+that's not just straight line execution of commands.  And if your project is written in Go, why
+introduce another language as idiosyncratic as bash?  Why not use the language your contributors are
+already comfortable with?
+
+## Compiling a static binary
+
+If your tasks are not related to compiling Go code, it can be useful to compile a binary which has
+the mage execution runtime and the tasks compiled in such that it can be run on another machine
+without requiring installation of dependencies. To do so, pass the output path to the compile flag.
+like this:
+
+```
+$ mage -compile ./static-output
+```
 
 ## Code
 

--- a/site/content/zeroInstall/_index.en.md
+++ b/site/content/zeroInstall/_index.en.md
@@ -40,3 +40,14 @@ All of mage's functionality is accessible as a compile-in library.  Checkout
 for full details.
 
 Fair warning, the API of mage/mage may change, so be sure to use vendoring.
+
+## Compiling a static binary
+
+If your tasks are not related to compiling Go code, it can be useful to compile a binary which has
+the mage execution runtime and the tasks compiled in such that it can be run on another machine
+without requiring installation of dependencies. To do so, pass the output path to the compile flag.
+like this:
+
+```
+$ mage -compile ./static-output
+```


### PR DESCRIPTION
This commit adds a new flag, `-compile`, which takes the argument of the path to which to compile a static binary, but not execute it. This is useful if you wish to run tasks on a machine which does not have Go available.

Examples:

```shell
$ mage -compile ./test

$ file ./test
./test: Mach-O 64-bit executable x86_64

$ nm ./test | grep Install
00000000010a8b50 t main.Install
```

```shell
$ GOOS=freebsd mage compile ./test

$ file ./test
test: ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD), statically linked, with debug_info, not stripped

$ nm ./test | grep Install
00000000004a7570 T main.Install
```