### PR TITLE
Add namespace/subcommand support to Mage

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -34,8 +34,12 @@ const magicRebuildKey = "v0.3"
 var output = template.Must(template.New("").Funcs(map[string]interface{}{
 	"lower": strings.ToLower,
 	"lowerfirst": func(s string) string {
-		r := []rune(s)
-		return string(unicode.ToLower(r[0])) + string(r[1:])
+		parts := strings.Split(s, ":")
+		for i, t := range parts {
+			r := []rune(t)
+			parts[i] = string(unicode.ToLower(r[0])) + string(r[1:])
+		}
+		return strings.Join(parts, ":")
 	},
 }).Parse(tpl))
 var initOutput = template.Must(template.New("").Parse(mageTpl))

--- a/mage/template.go
+++ b/mage/template.go
@@ -24,7 +24,7 @@ func main() {
 		w := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
 		fmt.Println("Targets:")
 		{{- range .Funcs}}
-		fmt.Fprintln(w, "  {{lowerfirst .Name}}{{if eq .Name $default}}*{{end}}\t" + {{printf "%q" .Synopsis}})
+		fmt.Fprintln(w, "  {{lowerfirst .TemplateName}}{{if eq .Name $default}}*{{end}}\t" + {{printf "%q" .Synopsis}})
 		{{- end}}
 		err := w.Flush()
 		{{- if .Default}}
@@ -115,7 +115,7 @@ func main() {
 	targets := map[string]bool {
 		{{range $alias, $funci := .Aliases}}"{{lower $alias}}": true,
 		{{end}}
-		{{range .Funcs}}"{{lower .Name}}": true,
+		{{range .Funcs}}"{{lower .TemplateName}}": true,
 		{{end}}
 	}
 
@@ -140,8 +140,8 @@ func main() {
 			os.Exit(1)
 		}
 		switch strings.ToLower(os.Args[1]) {
-			{{range .Funcs}}case "{{lower .Name}}":
-				fmt.Print("mage {{lower .Name}}:\n\n")
+			{{range .Funcs}}case "{{lower .TemplateName}}":
+				fmt.Print("mage {{lower .TemplateName}}:\n\n")
 				{{if ne .Comment ""}}fmt.Println({{printf "%q" .Comment}}){{end}}
 				var aliases []string
 				{{- $name := .Name -}}
@@ -181,9 +181,9 @@ func main() {
 		}
 		switch strings.ToLower(target) {
 		{{range .Funcs }}
-		case "{{lower .Name}}":
+		case "{{lower .TemplateName}}":
 			if os.Getenv("MAGEFILE_VERBOSE") != "" {
-				logger.Println("Running target:", "{{.Name}}")
+				logger.Println("Running target:", "{{.TemplateName}}")
 			}
 			{{.TemplateString}}
 			handleError(logger, err)

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -34,3 +34,6 @@ func CacheDir() string {
 		return filepath.Join(os.Getenv("HOME"), ".magefile")
 	}
 }
+
+// Namespace allows for the grouping of similar commands
+type Namespace struct{}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	info, err := Package("./testdata", []string{"func.go", "command.go", "alias.go", "repeating_synopsis.go"})
+	info, err := Package("./testdata", []string{"func.go", "command.go", "alias.go", "repeating_synopsis.go", "subcommands.go"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,6 +36,16 @@ func TestParse(t *testing.T) {
 			IsError:  true,
 			Comment:  "RepeatingSynopsis chops off the repeating function name.\nSome more text.\n",
 			Synopsis: "chops off the repeating function name.",
+		},
+		{
+			Name:     "Foobar",
+			Receiver: "Build",
+			IsError:  true,
+		},
+		{
+			Name:     "Baz",
+			Receiver: "Build",
+			IsError:  false,
 		},
 	}
 

--- a/parse/testdata/subcommands.go
+++ b/parse/testdata/subcommands.go
@@ -1,0 +1,15 @@
+// +build mage
+package main
+
+import "github.com/magefile/mage/mg"
+
+type Build mg.Namespace
+
+func (Build) Foobar() error {
+	// do your foobar build
+	return nil
+}
+
+func (Build) Baz() {
+	// do your baz build
+}


### PR DESCRIPTION
This delivers #119 as it is something that I wanted to see available. I've never worked with the `go/ast` package before, so I may be doing some things in a less than ideal way.

This enables the nearly the exact syntax outlined in #119 to work.

```go
type Build mg.Namespace

func (Build) Foobar() error {
    // do your foobar build
    return nil
}

func (Build) Baz() error {
    // do your baz build
    return nil
}
```
With that, the functions are now exposed in a namespaced fashion:

```
$ mage -l
Targets:
  build:foobar
  build:baz
```