### PR TITLE
Log dependencies in runDeps

### DIFF
--- a/mg/deps.go
+++ b/mg/deps.go
@@ -92,7 +92,7 @@ func runDeps(ctx context.Context, fns ...interface{}) {
 				}
 				wg.Done()
 			}()
-			if os.Getenv("MAGEFILE_VERBOSE") != "" {
+			if Verbose() {
 				logger.Println("Running dependency:", fn.displayName)
 			}
 			if err := fn.run(); err != nil {

--- a/mg/deps.go
+++ b/mg/deps.go
@@ -13,6 +13,8 @@ import (
 	"github.com/magefile/mage/types"
 )
 
+var logger = log.New(os.Stderr, "", 0)
+
 type onceMap struct {
 	mu *sync.Mutex
 	m  map[string]*onceFun
@@ -77,7 +79,6 @@ func runDeps(ctx context.Context, fns ...interface{}) {
 	for _, f := range fns {
 		fn := addDep(ctx, f)
 		wg.Add(1)
-		logger := log.New(os.Stderr, "", 0)
 		go func() {
 			defer func() {
 				if v := recover(); v != nil {

--- a/mg/deps.go
+++ b/mg/deps.go
@@ -161,7 +161,10 @@ func name(i interface{}) string {
 
 func displayName(name string) string {
 	splitByPackage := strings.Split(name, ".")
-	return splitByPackage[len(splitByPackage)-1]
+	if len(splitByPackage) == 2 && splitByPackage[0] == "main" {
+		return splitByPackage[len(splitByPackage)-1]
+	}
+	return name
 }
 
 type onceFun struct {

--- a/mg/deps_internal_test.go
+++ b/mg/deps_internal_test.go
@@ -1,0 +1,31 @@
+package mg
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDepsOfDeps(t *testing.T) {
+	os.Setenv("MAGEFILE_VERBOSE", "1")
+	defer os.Unsetenv("MAGEFILE_VERBOSE")
+	buf := bytes.NewBuffer(make([]byte, 4096))
+
+	defaultLogger := logger
+	logger = log.New(buf, "", 0)
+	defer func() { logger = defaultLogger }()
+
+	ch := make(chan string, 1)
+	f := func() {
+		Deps(func() {})
+		ch <- "f"
+	}
+	Deps(f)
+
+	<-ch
+	if !strings.Contains(buf.String(), "Running dependency") {
+		t.Fatal("expected dependencies to be logged")
+	}
+}


### PR DESCRIPTION
Closes #110.
With this commit, `mage` prints executed dependencies when using `-v`:

```
$ mage -v buildWithDeps
Running target: BuildWithDeps
Running dependency: Build
```