### PR TITLE
fix target library

### DIFF
--- a/target/target_test.go
+++ b/target/target_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestMissingPathTarget(t *testing.T) {
+func TestPathMissingDest(t *testing.T) {
 	t.Parallel()
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -16,7 +16,7 @@ func TestMissingPathTarget(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	src := filepath.Join(dir, "source")
-	err = ioutil.WriteFile(filepath.Join(dir, "source"), []byte("hi!"), 0644)
+	err = ioutil.WriteFile(src, []byte("hi!"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,45 @@ func TestMissingPathTarget(t *testing.T) {
 	}
 }
 
-func TestMissingDirTarget(t *testing.T) {
+func TestPathMissingSource(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	dst := filepath.Join(dir, "dst")
+	err = ioutil.WriteFile(dst, []byte("hi!"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(dir, "missing")
+	_, err = Path(dst, src)
+	if !os.IsNotExist(err) {
+		t.Fatal("Expected os.IsNotExist(err), but got", err)
+	}
+}
+
+func TestDirMissingSrc(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	dst := filepath.Join(dir, "dst")
+	err = ioutil.WriteFile(dst, []byte("hi!"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(dir, "missing")
+	_, err = Dir(dst, src)
+	if !os.IsNotExist(err) {
+		t.Fatal("Expected os.IsNotExist(err), but got", err)
+	}
+}
+
+func TestDirMissingDest(t *testing.T) {
 	t.Parallel()
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -38,7 +76,7 @@ func TestMissingDirTarget(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	src := filepath.Join(dir, "source")
-	err = os.Mkdir(filepath.Join(dir, "source"), 0755)
+	err = os.Mkdir(src, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/target/target_test.go
+++ b/target/target_test.go
@@ -3,61 +3,243 @@ package target
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
+func TestMissingPathTarget(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	src := filepath.Join(dir, "source")
+	err = ioutil.WriteFile(filepath.Join(dir, "source"), []byte("hi!"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "missing")
+	rebuild, err := Path(dst, src)
+	if err != nil {
+		t.Fatal("Expected no error, but got", err)
+	}
+	if !rebuild {
+		t.Fatal("expected to be told to rebuild, but got false")
+	}
+}
+
+func TestMissingDirTarget(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	src := filepath.Join(dir, "source")
+	err = os.Mkdir(filepath.Join(dir, "source"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(src, "somefile"), []byte("hi!"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "missing")
+	rebuild, err := Dir(dst, src)
+	if err != nil {
+		t.Fatal("Expected no error, but got", err)
+	}
+	if !rebuild {
+		t.Fatal("expected to be told to rebuild, but got false")
+	}
+}
+
 func TestPath(t *testing.T) {
 	t.Parallel()
-	dirs := []string{"testdata/src_dir", "testdata/target_dir"}
-	for _, d := range dirs {
-		os.MkdirAll(d, 0777)
-		time.Sleep(10 * time.Millisecond)
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
+
+	err = os.MkdirAll(filepath.Join(dir, filepath.FromSlash("dir/dir2")), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// files are created in order so we know how to expect
 	files := []string{
-		"testdata/src_dir/some_file",
-		"testdata/src_dir/some_",
-		"testdata/src_file",
-		"testdata/target_dir/some_file",
-		"testdata/target_file",
+		"file_one",
+		"dir/file_two",
+		"file_three",
+		"dir/dir2/file_four",
 	}
 	for _, v := range files {
-		err := ioutil.WriteFile(v, []byte(v), 0600)
+		time.Sleep(10 * time.Millisecond)
+		f := filepath.Join(dir, filepath.FromSlash(v))
+		err := ioutil.WriteFile(f, []byte(v), 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(500 * time.Millisecond)
 	}
-	defer func() {
-		err := os.RemoveAll("testdata")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
 
 	table := []struct {
 		desc    string
-		src     string
-		targets []string
+		target  string
+		sources []string
 		expect  bool
 	}{
-		{"Files only target checks", "testdata/src_file",
-			[]string{"testdata/target_file"}, true},
-		{"Files only target doesn't check", "testdata/target_file",
-			[]string{"testdata/src_file"}, false},
-		{"Directories only target checks", "testdata/src_dir",
-			[]string{"testdata/target_dir"}, true},
-		{"Directories only target doesn't  checks", "testdata/target_dir",
-			[]string{"testdata/src_dir"}, false},
+		{
+			desc:    "Missing target",
+			target:  "missing_file",
+			sources: []string{"file_one"},
+			expect:  true,
+		},
+		{
+			desc:    "Target is newer",
+			target:  "file_three",
+			sources: []string{"file_one"},
+			expect:  false,
+		},
+		{
+			desc:    "Target is older",
+			target:  "file_one",
+			sources: []string{"file_three"},
+			expect:  true,
+		},
+		{
+			// note that even though file_four is in dir/dir2 ... the modtimes
+			// only get propagated up to the parent directory of the folder, not
+			// propagated all the way up.
+			desc:    "Source is older dir",
+			target:  "file_three",
+			sources: []string{"dir"},
+			expect:  false,
+		},
+		{
+			desc:    "Source is newer dir2",
+			target:  "file_three",
+			sources: []string{"dir/dir2"},
+			expect:  true,
+		},
+		{
+			desc:    "Source is newer dir",
+			target:  "file_one",
+			sources: []string{"dir"},
+			expect:  true,
+		},
 	}
 
 	for _, c := range table {
-		v, err := Path(c.src, c.targets...)
+		t.Run(c.desc, func(t *testing.T) {
+			for i := range c.sources {
+				c.sources[i] = filepath.Join(dir, c.sources[i])
+			}
+			c.target = filepath.Join(dir, c.target)
+			v, err := Path(c.target, c.sources...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v != c.expect {
+				t.Errorf("expecting %v got %v", c.expect, v)
+			}
+		})
+	}
+}
+
+func TestDir(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	err = os.MkdirAll(filepath.Join(dir, filepath.FromSlash("dir/dir2")), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// files are created in order so we know which one is newer
+	files := []string{
+		"file_one",
+		"dir/file_two",
+		"file_three",
+		"dir/dir2/file_four",
+		"file_five",
+	}
+	for _, v := range files {
+		time.Sleep(10 * time.Millisecond)
+		f := filepath.Join(dir, filepath.FromSlash(v))
+		err := ioutil.WriteFile(f, []byte(v), 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if v != c.expect {
-			t.Errorf("%s : expecting %v got %v", c.desc, c.expect, v)
-		}
+	}
+
+	table := []struct {
+		desc    string
+		target  string
+		sources []string
+		expect  bool
+	}{
+		{
+			desc:    "Missing target",
+			target:  "missing_file",
+			sources: []string{"file_one"},
+			expect:  true,
+		},
+		{
+			desc:    "Target is newer",
+			target:  "file_three",
+			sources: []string{"file_one"},
+			expect:  false,
+		},
+		{
+			desc:    "Target is older",
+			target:  "file_one",
+			sources: []string{"file_three"},
+			expect:  true,
+		},
+		{
+			desc:    "Source is older dir",
+			target:  "file_five",
+			sources: []string{"dir"},
+			expect:  false,
+		},
+		{
+			desc:    "Source is newer dir",
+			target:  "file_one",
+			sources: []string{"dir"},
+			expect:  true,
+		},
+		{
+			// This is the tricky one. The modtime on "dir" will be the same
+			// as the modtime on dir/file_two, but the modtime on the subdir
+			// will be the same as the modtime on dir/dir2/file_four
+			// and therefor the should say the source is newer.
+			desc:    "Source is newer subdir",
+			target:  "file_three",
+			sources: []string{"dir"},
+			expect:  true,
+		},
+	}
+
+	for _, c := range table {
+		t.Run(c.desc, func(t *testing.T) {
+			sources := make([]string, len(c.sources))
+			for i := range c.sources {
+				sources[i] = filepath.Join(dir, c.sources[i])
+			}
+			target := filepath.Join(dir, c.target)
+			v, err := Dir(target, sources...)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			if v != c.expect {
+				t.Errorf("expecting %v got %v", c.expect, v)
+			}
+		})
 	}
 }


### PR DESCRIPTION
There were a few different problems with this library, which were a lot clearer
with added tests. The main change is to fix it such that if the target is missing
we automatically call it as needing to be regenerated.  Plus target.Path was 
just plain broken.