### PR TITLE
Fix dependency logging

### DIFF
--- a/mg/deps.go
+++ b/mg/deps.go
@@ -93,9 +93,6 @@ func runDeps(ctx context.Context, fns ...interface{}) {
 				}
 				wg.Done()
 			}()
-			if Verbose() {
-				logger.Println("Running dependency:", fn.displayName)
-			}
 			if err := fn.run(); err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Sprint(err))
@@ -182,6 +179,9 @@ type onceFun struct {
 func (o *onceFun) run() error {
 	var err error
 	o.once.Do(func() {
+		if Verbose() {
+			logger.Println("Running dependency:", o.displayName)
+		}
 		err = o.fn(o.ctx)
 	})
 	return err

--- a/mg/deps_internal_test.go
+++ b/mg/deps_internal_test.go
@@ -11,21 +11,25 @@ import (
 func TestDepsOfDeps(t *testing.T) {
 	os.Setenv("MAGEFILE_VERBOSE", "1")
 	defer os.Unsetenv("MAGEFILE_VERBOSE")
-	buf := bytes.NewBuffer(make([]byte, 4096))
+	buf := &bytes.Buffer{}
 
 	defaultLogger := logger
 	logger = log.New(buf, "", 0)
 	defer func() { logger = defaultLogger }()
 
-	ch := make(chan string, 1)
-	f := func() {
-		Deps(func() {})
-		ch <- "f"
-	}
-	Deps(f)
+	foo()
 
-	<-ch
-	if !strings.Contains(buf.String(), "Running dependency") {
-		t.Fatal("expected dependencies to be logged")
+	if strings.Count(buf.String(), "Running dependency: github.com/magefile/mage/mg.baz") != 1 {
+		t.Fatalf("expected one baz to be logged, but got\n%s", buf)
 	}
 }
+
+func foo() {
+	Deps(bar, baz)
+}
+
+func bar() {
+	Deps(baz)
+}
+
+func baz() {}


### PR DESCRIPTION
we were logging outside the sync.once which means we'd log
even if we didn't actually run the function