### PR TITLE
make version not say v2 by default

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -57,7 +57,7 @@ var debug = log.New(ioutil.Discard, "DEBUG: ", 0)
 var (
 	commitHash string
 	timestamp  string
-	gitTag     = "v2"
+	gitTag     = "unknown"
 )
 
 //go:generate stringer -type=Command


### PR DESCRIPTION
It was confusing and now it's going to be incorrect