### PR TITLE
Website tweaks

### DIFF
--- a/site/content/environment/_index.en.md
+++ b/site/content/environment/_index.en.md
@@ -13,7 +13,7 @@ Set to "1" or "true" to turn on debug mode (like running with -debug)
 
 ## MAGEFILE_CACHE
 
-Sets the directory where mage will store binaries compiled from magefiles.
+Sets the directory where mage will store binaries compiled from magefiles (default is $HOME/.magefile)
 
 ## MAGEFILE_GOCMD
 

--- a/site/content/howitworks/_index.en.md
+++ b/site/content/howitworks/_index.en.md
@@ -18,6 +18,7 @@ customized by setting the MAGEFILE_CACHE environment variable.
 
 ## Go Environment
 
-Mage itself requires no dependencies to run. However, because it is compiling
-go code, you must have a valid go environment set up on your machine.  Mage is
-compatible with any go 1.x environment.
+Mage itself requires no dependencies to run. However, because it is compiling go
+code, you must have a valid go environment set up on your machine.  Mage is
+compatible with any go 1.7+ environment (earlier versions may work but are not
+tested).

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -1,0 +1,11 @@
+{{ partial "header.html" . }}
+
+  {{.Content}}
+
+  <ul class="posts">
+      {{ range .Data.Pages }}
+      <li><span><a href="{{ .Permalink }}">{{ .Title }}</a><time class="pull-right post-list">{{ .Date.Format "Mon, Jan 2, 2006" }}</h4></time></span></span></li>
+      {{ end }}
+  </ul>
+
+{{ partial "footer.html" . }}

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -44,7 +44,7 @@
         <div id="overlay"></div>
         <div class="padding highlightable sticky-parent">
               {{if not .IsHome}}
-              <div class="sticky-spacer">
+              <div>
                 <div id="top-bar">
                 {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
                   {{ $File := .File }}

--- a/site/themes/learn/layouts/_default/list.html
+++ b/site/themes/learn/layouts/_default/list.html
@@ -1,11 +1,12 @@
 {{ partial "header.html" . }}
-<body>
 
+{{ .Content }}
 
-  <ul class="posts">
-      {{ range .Data.Pages }}
-      <li><span><a href="{{ .Permalink }}">{{ .Title }}</a><time class="pull-right post-list">{{ .Date.Format "Mon, Jan 2, 2006" }}</h4></time></span></span></li>
-      {{ end }}
-  </ul>
+<footer class=" footline" >
+	{{with .Params.LastModifierDisplayName}}
+	    <i class='fa fa-user'></i> <a href="mailto:{{ $.Params.LastModifierEmail }}">{{ . }}</a> {{with $.Date}} <i class='fa fa-calendar'></i> {{ .Format "02/01/2006" }}{{end}}
+	    </div>
+	{{end}}
+</footer>
 
 {{ partial "footer.html" . }}

--- a/site/themes/learn/layouts/partials/header.html
+++ b/site/themes/learn/layouts/partials/header.html
@@ -41,7 +41,7 @@
         <div id="overlay"></div>
         <div class="padding highlightable sticky-parent">
               {{if not .IsHome}}
-              <div class="sticky-spacer">
+              <div>
                 <div id="top-bar">
                 {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
                   {{ $File := .File }}

--- a/site/themes/learn/static/css/theme.css
+++ b/site/themes/learn/static/css/theme.css
@@ -411,7 +411,7 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 #body-inner {
     margin-bottom: 5rem;
     margin: auto;
-    max-width: 800px;
+    max-width: 900px;
 }
 #chapter {
     display: flex;

--- a/site/themes/learn/static/css/theme.css
+++ b/site/themes/learn/static/css/theme.css
@@ -410,6 +410,8 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 }
 #body-inner {
     margin-bottom: 5rem;
+    margin: auto;
+    max-width: 800px;
 }
 #chapter {
     display: flex;

--- a/site/themes/learn/static/css/theme.css
+++ b/site/themes/learn/static/css/theme.css
@@ -35,7 +35,7 @@
     src: url("../fonts/Work_Sans_500.eot?#iefix") format("embedded-opentype"), url("../fonts/Work_Sans_500.woff") format("woff"), url("../fonts/Work_Sans_500.woff2") format("woff2"), url("../fonts/Work_Sans_500.svg#WorkSans") format("svg"), url("../fonts/Work_Sans_500.ttf") format("truetype");
 }
 body {
-    background: #fff;
+    background: #f5f5f5;
     color: #777;
 }
 body #chapter h1 {
@@ -314,7 +314,6 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
     text-indent: 0.2rem;
 }
 #main {
-    background: #f7f7f7;
     margin: 0 0 1.563rem 0;
 }
 #body {
@@ -407,11 +406,16 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 }
 #body .nav.nav-next {
     right: 0;
+
 }
 #body-inner {
     margin-bottom: 5rem;
+    background-color: #fff;
     margin: auto;
     max-width: 900px;
+    padding-left: 20px;
+    padding-bottom: 5px;
+    padding-right: 20px;
 }
 #chapter {
     display: flex;


### PR DESCRIPTION
Set maxwidth on pages so they're not such wide lines of text.  Set background to be a bit darker so that you have some border box to keep your eyes in.  Fix a bug where we weren't printing out the body of content other than blog posts.  And fix the breadcrumbs at the top so they'll resize when the window does.