### PR TITLE
Add support for bash completion

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1,7 +1,7 @@
 _mage() {
 	# Get the partial word typed by the user.
 	local PARTIAL_WORD
-	PARTIAL_WORD="$(echo "$2" | tr '[:upper:]' '[:lower:]')"
+	PARTIAL_WORD="$2"
 
 	# Narrow in on a category of completions to offer.
 	local CATEGORY

--- a/bash_completion
+++ b/bash_completion
@@ -1,0 +1,28 @@
+_mage() {
+	# Get the partial word typed by the user.
+	local PARTIAL_WORD
+	PARTIAL_WORD="$(echo "$2" | tr '[:upper:]' '[:lower:]')"
+
+	# Narrow in on a category of completions to offer.
+	local CATEGORY
+	case "$PARTIAL_WORD" in
+		-*)
+			# Flags
+			CATEGORY="$(mage -h | grep '^  -' | cut -d' ' -f3)"
+			;;
+		*)
+			# Targets
+			CATEGORY="$(mage -l | grep '^  ' | cut -d' ' -f3)"
+			;;
+	esac
+
+	# Discard the completions not matching the typed prefix.
+	local FILTERED_COMPLETIONS
+	FILTERED_COMPLETIONS="$(compgen -W "$CATEGORY" -- "$PARTIAL_WORD")"
+
+	# Communicate the result to Bash using an array.
+	COMPREPLY=($FILTERED_COMPLETIONS)
+}
+
+# Hook up our completion function.
+complete -F _mage mage

--- a/magefile.go
+++ b/magefile.go
@@ -77,6 +77,17 @@ func Clean() error {
 	return sh.Rm("dist")
 }
 
+func InstallCompletion() error {
+	completionDir := "/etc/bash_completion.d"
+	if runtime.GOOS == "darwin" {
+		completionDir = "/usr/local/etc/bash_completion.d"
+	}
+	if _, err := os.Stat(completionDir); err != nil {
+		return err
+	}
+	return sh.Copy(filepath.Join(completionDir, "mage"), "bash_completion")
+}
+
 func flags() string {
 	timestamp := time.Now().Format(time.RFC3339)
 	hash := hash()


### PR DESCRIPTION
Hi there - give this a try. It can be loaded by adding this to one's `.bash_profile`:

`. "$GOPATH/src/github.com/magefile/mage/bash_completion"`

---

Mage's own magefile could probably have a target to make the above step unnecessary. It would have to find the system's `bash_completion.d` directory (e.g. `/usr/local/etc/bash_completion.d`) and create a symlink in it to our script, which would result in automatic loading.

Fixes #113 
