### PR TITLE
make sure we return the same error the original dep function returned

### DIFF
--- a/mg/deps.go
+++ b/mg/deps.go
@@ -199,19 +199,19 @@ type onceFun struct {
 	once sync.Once
 	fn   func(context.Context) error
 	ctx  context.Context
+	err  error
 
 	displayName string
 }
 
 func (o *onceFun) run() error {
-	var err error
 	o.once.Do(func() {
 		if Verbose() {
 			logger.Println("Running dependency:", o.displayName)
 		}
-		err = o.fn(o.ctx)
+		o.err = o.fn(o.ctx)
 	})
-	return err
+	return o.err
 }
 
 // funcCheck tests if a function is one of funcType


### PR DESCRIPTION
If you had a tree of deps and the same dep was called from two different branches... it only gets called once.  That works, but the error wasn't getting propagated to the other branch, so it wouldn't stop execution.  Now it does.