### PR TITLE
MAGEFILE_IGNOREDEFAULT flag

### DIFF
--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -195,6 +195,41 @@ Targets:
 	}
 }
 
+func TestIgnoreDefault(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/list",
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	defer os.Setenv(mg.IgnoreDefaultEnv, os.Getenv(mg.IgnoreDefaultEnv))
+	if err := os.Setenv(mg.IgnoreDefaultEnv, "1"); err != nil {
+		t.Fatal(err)
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Errorf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := `
+This is a comment on the package which should get turned into output with the list of targets.
+
+Targets:
+  somePig*       This is the synopsis for SomePig.
+  testVerbose    
+
+* default target
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}
+
 func TestTargetError(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	inv := Invocation{

--- a/mage/template.go
+++ b/mage/template.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -165,6 +166,14 @@ func main() {
 
 	if len(os.Args) < 2 {
 	{{- if .Default}}
+		ignore, _ := strconv.ParseBool(os.Getenv("MAGEFILE_IGNOREDEFAULT"))
+		if ignore {
+			if err := list(); err != nil {
+				logger.Println("Error:", err)
+				os.Exit(1)
+			}
+			return	
+		}
 		{{.DefaultFunc.TemplateString}}
 		handleError(logger, err)
 		return

--- a/mage/template.go
+++ b/mage/template.go
@@ -163,7 +163,8 @@ func main() {
 				os.Exit(1)
 		}	
 	}
-
+	// to avoid unused import
+	_ = strconv.ParseBool
 	if len(os.Args) < 2 {
 	{{- if .Default}}
 		ignore, _ := strconv.ParseBool(os.Getenv("MAGEFILE_IGNOREDEFAULT"))

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -23,6 +23,10 @@ const DebugEnv = "MAGEFILE_DEBUG"
 // verbose mode when running a magefile.
 const GoCmdEnv = "MAGEFILE_GOCMD"
 
+// IgnoreDefaultEnv is the environment variable that indicates the user requested
+// to ignore the default target specified in the magefile.
+const IgnoreDefaultEnv = "MAGEFILE_IGNOREDEFAULT"
+
 // Verbose reports whether a magefile was run with the verbose flag.
 func Verbose() bool {
 	b, _ := strconv.ParseBool(os.Getenv(VerboseEnv))
@@ -42,6 +46,13 @@ func GoCmd() string {
 		return cmd
 	}
 	return "go"
+}
+
+// IgnoreDefault reports whether the user has requested to ignore the default target
+// in the magefile.
+func IgnoreDefault() bool {
+	b, _ := strconv.ParseBool(os.Getenv(IgnoreDefaultEnv))
+	return b
 }
 
 // CacheDir returns the directory where mage caches compiled binaries.  It

--- a/site/content/environment/_index.en.md
+++ b/site/content/environment/_index.en.md
@@ -13,8 +13,14 @@ Set to "1" or "true" to turn on debug mode (like running with -debug)
 
 ## MAGEFILE_CACHE
 
-Sets the directory where mage will store binaries compiled from magefiles (default is $HOME/.magefile)
+Sets the directory where mage will store binaries compiled from magefiles
+(default is $HOME/.magefile)
 
 ## MAGEFILE_GOCMD
 
 Sets the binary that mage will use to compile with (default is "go").
+
+## MAGEFILE_IGNOREDEFAULT
+
+If set to 1 or true, will tell the compiled magefile to ignore the default
+target and print the list of targets when you run `mage`.


### PR DESCRIPTION
If set to 1 or true, mage will ignore the default target set in magefiles and always print the list of targets when you run just `mage`.  Resolves #161