### PR TITLE
Addresses file move error in Docker.

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -578,7 +578,7 @@ func useExistingMain(cachedMain, path, hash string) bool {
 		debug.Printf("error copying cached mainfile from %s to %s: %v", cachedMain, path, err)
 	}
 	// Remove the file.
-	if err = os.Remove(cachedMain); err == nil {
+	if err = os.Remove(cachedMain); err != nil {
 		debug.Println("error removing cached mainfile from cachedir: ", err)
 		return true
 	}

--- a/mage/main.go
+++ b/mage/main.go
@@ -569,7 +569,7 @@ func useExistingMain(cachedMain, path, hash string) bool {
 	// Copy the file.
 	err := copy(cachedMain, path)
 	if err == nil {
-		debug.Println("error copying cached mainfile from cachedir: ", err)
+		debug.Println("using cached mainfile from cachedir")
 		return true
 	}
 	if os.IsNotExist(err) {

--- a/mage/main.go
+++ b/mage/main.go
@@ -569,7 +569,7 @@ func useExistingMain(cachedMain, path, hash string) bool {
 	// Copy the file.
 	err := copy(cachedMain, path)
 	if err == nil {
-		debug.Println("using cached mainfile from cachedir")
+		debug.Println("error copying cached mainfile from cachedir: ", err)
 		return true
 	}
 	if os.IsNotExist(err) {
@@ -579,7 +579,7 @@ func useExistingMain(cachedMain, path, hash string) bool {
 	}
 	// Remove the file.
 	if err = os.Remove(cachedMain); err == nil {
-		debug.Println("error removing cached mainfile from cachedir")
+		debug.Println("error removing cached mainfile from cachedir: ", err)
 		return true
 	}
 	// ok, no cached file, try to open the file at the target (happens if

--- a/mage/main.go
+++ b/mage/main.go
@@ -580,7 +580,7 @@ func useExistingMain(cachedMain, path, hash string) bool {
 	// Remove the file.
 	if err = os.Remove(cachedMain); err != nil {
 		debug.Println("error removing cached mainfile from cachedir: ", err)
-		return true
+		return false
 	}
 	// ok, no cached file, try to open the file at the target (happens if
 	// the user ran with -keep)


### PR DESCRIPTION
Addressed the error I was experiencing in Docker containers where copying to, or from, the cache dir. was resulting in an error.

Example:
`DEBUG: 19:26:06.869194 error caching main file:  rename /go/src/github.com/<my>/<repo>/mage_output_file.go /root/.magefile/mainfiles/516a98d0b7cb5d2401fd03b8abe3ebdb5f72ba26: invalid cross-device link`

- This also addressed a couple instances of variable shadowing (thanks `go vet`).
- Aaaaand, a trailing space is removed. :)