### PR TITLE
actually parse the MAGEFILE_VERBOSE flag

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -432,11 +432,11 @@ func Magefiles(magePath, goCmd string, stderr io.Writer, isDebug bool) ([]string
 	}
 	cmd.Dir = magePath
 	b, err = cmd.Output()
-	list = strings.TrimSpace(string(b))
-
 	if err != nil {
 		return fail(fmt.Errorf("failed to list mage gofiles: %v", err))
 	}
+
+	list = strings.TrimSpace(string(b))
 	files := []string{}
 	for _, f := range strings.Split(list, "||") {
 		if f != "" && !exclude[f] {

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -191,7 +191,19 @@ func TestVerboseEnv(t *testing.T) {
 	if inv.Verbose != true {
 		t.Fatalf("expected %t, but got %t ", expected, inv.Verbose)
 	}
+}
+func TestVerboseFalseEnv(t *testing.T) {
+	os.Setenv("MAGEFILE_VERBOSE", "0")
+	defer os.Unsetenv("MAGEFILE_VERBOSE")
+	stdout := &bytes.Buffer{}
+	code := ParseAndRun(ioutil.Discard, stdout, nil, []string{"-d", "testdata", "testverbose"})
+	if code != 0 {
+		t.Fatal("unexpected code", code)
+	}
 
+	if stdout.String() != "" {
+		t.Fatalf("expected no output, but got %s", stdout.String())
+	}
 }
 
 func TestList(t *testing.T) {

--- a/mage/template.go
+++ b/mage/template.go
@@ -102,7 +102,7 @@ func main() {
 	_ = handleError
 
 	log.SetFlags(0)
-	if os.Getenv("MAGEFILE_VERBOSE") == "" {
+	if verbose, _ := strconv.ParseBool(os.Getenv("MAGEFILE_VERBOSE")); !verbose {
 		log.SetOutput(ioutil.Discard)
 	}
 	logger := log.New(os.Stderr, "", 0)
@@ -163,8 +163,6 @@ func main() {
 				os.Exit(1)
 		}	
 	}
-	// to avoid unused import
-	_ = strconv.ParseBool
 	if len(os.Args) < 2 {
 	{{- if .Default}}
 		ignore, _ := strconv.ParseBool(os.Getenv("MAGEFILE_IGNOREDEFAULT"))

--- a/mage/template.go
+++ b/mage/template.go
@@ -102,7 +102,8 @@ func main() {
 	_ = handleError
 
 	log.SetFlags(0)
-	if verbose, _ := strconv.ParseBool(os.Getenv("MAGEFILE_VERBOSE")); !verbose {
+	verbose, _ := strconv.ParseBool(os.Getenv("MAGEFILE_VERBOSE"))
+	if !verbose {
 		log.SetOutput(ioutil.Discard)
 	}
 	logger := log.New(os.Stderr, "", 0)
@@ -194,7 +195,7 @@ func main() {
 		switch strings.ToLower(target) {
 		{{range .Funcs }}
 		case "{{lower .TemplateName}}":
-			if os.Getenv("MAGEFILE_VERBOSE") != "" {
+			if verbose {
 				logger.Println("Running target:", "{{.TemplateName}}")
 			}
 			{{.TemplateString}}


### PR DESCRIPTION
turns out that we weren't parsing the MAGEFILE_VERBOSE flag, we were just checking if it
was empty or not.  So if you set it to 0, the code would think you were turning on
verbose mode.  Note that this only really affected the use of the default log package
logger, so it was kind of hard to see.  Fixed now, at least.