### PR TITLE
implement importing magefiles

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -1,0 +1,38 @@
+package mage
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMageImportsList(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		List:   true,
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := `
+This is a comment on the package which should get turned into output with the list of targets.
+
+Targets:
+  somePig*       This is the synopsis for SomePig.
+  testVerbose    
+
+* default target
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}

--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -21,18 +21,122 @@ func TestMageImportsList(t *testing.T) {
 	}
 	actual := stdout.String()
 	expected := `
-This is a comment on the package which should get turned into output with the list of targets.
-
 Targets:
-  somePig*       This is the synopsis for SomePig.
-  testVerbose    
-
-* default target
+  root               
+  zz:nS:deploy2      deploys stuff.
+  zz:buildSubdir2    Builds stuff.
+  nS:deploy          deploys stuff.
+  buildSubdir        Builds stuff.
 `[1:]
 
 	if actual != expected {
 		t.Logf("expected: %q", expected)
 		t.Logf("  actual: %q", actual)
 		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}
+
+func TestMageImportsRoot(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"root"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "root\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
+	}
+}
+
+func TestMageImportsNamedNS(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"zz:nS:deploy2"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "deploy2\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
+	}
+}
+
+func TestMageImportsNamedRoot(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"zz:buildSubdir2"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "buildsubdir2\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
+	}
+}
+
+func TestMageImportsRootImportNS(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"nS:deploy"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "deploy\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
+	}
+}
+
+func TestMageImportsRootImport(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"buildSubdir"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "buildsubdir\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
 	}
 }

--- a/mage/main.go
+++ b/mage/main.go
@@ -32,7 +32,7 @@ const magicRebuildKey = "v0.3"
 
 var output = template.Must(template.New("").Funcs(map[string]interface{}{
 	"lower": strings.ToLower,
-	"lowerfirst": func(s string) string {
+	"lowerFirst": func(s string) string {
 		parts := strings.Split(s, ":")
 		for i, t := range parts {
 			r := []rune(t)

--- a/mage/template.go
+++ b/mage/template.go
@@ -29,11 +29,11 @@ func main() {
 		w := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
 		fmt.Println("Targets:")
 		{{- range .Funcs}}
-			fmt.Fprintln(w, "  {{.TargetName}}{{if and (eq .Name $default.Name) (eq .Receiver $default.Receiver)}}*{{end}}\t" + {{printf "%q" .Synopsis}})
+			fmt.Fprintln(w, "  {{lowerFirst .TargetName}}{{if and (eq .Name $default.Name) (eq .Receiver $default.Receiver)}}*{{end}}\t" + {{printf "%q" .Synopsis}})
 		{{- end}}
 		{{- range .Imports}}{{$imp := .}}
 			{{- range .Info.Funcs}}
-			fmt.Fprintln(w, "  {{.TargetName}}{{if and (eq .Name $default.Name) (eq .Receiver $default.Receiver)}}*{{end}}\t" + {{printf "%q" .Synopsis}})
+			fmt.Fprintln(w, "  {{lowerFirst .TargetName}}{{if and (eq .Name $default.Name) (eq .Receiver $default.Receiver)}}*{{end}}\t" + {{printf "%q" .Synopsis}})
 			{{end}}
 		{{- end}}
 		err := w.Flush()
@@ -126,13 +126,13 @@ func main() {
 	targets := map[string]bool {
 		{{range $alias, $funci := .Aliases}}"{{lower $alias}}": true,
 		{{end}}
-		{{range .Funcs}}"{{.TargetName}}": true,
+		{{range .Funcs}}"{{lower .TargetName}}": true,
 		{{end}}
 		{{range .Imports}}
 			{{$imp := .}}
 			{{range $alias, $funci := .Info.Aliases}}"{{if ne $imp.Alias "."}}{{lower $imp.Alias}}:{{end}}{{lower $alias}}": true,
 			{{end}}
-			{{range .Info.Funcs}}"{{.TargetName}}": true,
+			{{range .Info.Funcs}}"{{lower .TargetName}}": true,
 			{{end}}
 		{{end}}
 	}
@@ -210,7 +210,7 @@ func main() {
 		}
 		switch strings.ToLower(target) {
 		{{range .Funcs }}
-			case "{{.TargetName}}":
+			case "{{lower .TargetName}}":
 				if verbose {
 					logger.Println("Running target:", "{{.TargetName}}")
 				}
@@ -220,7 +220,7 @@ func main() {
 		{{range .Imports}}
 		{{$imp := .}}
 			{{range .Info.Funcs }}
-				case "{{.TargetName}}":
+				case "{{lower .TargetName}}":
 					if verbose {
 						logger.Println("Running target:", "{{.TargetName}}")
 					}

--- a/mage/template.go
+++ b/mage/template.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
-	{{range .Imports}}"{{.Path}}"
+	{{range .Imports}}{{.UniqueName}} "{{.Path}}"
 	{{end}}
 )
 

--- a/mage/testdata/mageimport/magefile.go
+++ b/mage/testdata/mageimport/magefile.go
@@ -2,7 +2,16 @@
 
 package main
 
+// important things to note:
+// * these two packages have the same package name, so they'll conflict
+// when imported.
+// * one is imported with underscore and one is imported normally.
+//
+// they should still work normally as mageimports
+
 import (
+	"fmt"
+
 	// mage:import
 	_ "github.com/magefile/mage/mage/testdata/mageimport/subdir1"
 	// mage:import zz
@@ -13,5 +22,5 @@ import (
 var _ = mage.BuildSubdir2
 
 func Root() {
-
+	fmt.Println("root")
 }

--- a/mage/testdata/mageimport/magefile.go
+++ b/mage/testdata/mageimport/magefile.go
@@ -1,0 +1,17 @@
+//+build mage
+
+package main
+
+import (
+	// mage:import
+	_ "github.com/magefile/mage/mage/testdata/mageimport/subdir1"
+	// mage:import zz
+	"github.com/magefile/mage/mage/testdata/mageimport/subdir2"
+)
+
+// just something to keep the import from being unused.
+var _ = mage.BuildSubdir2
+
+func Root() {
+
+}

--- a/mage/testdata/mageimport/subdir1/mage.go
+++ b/mage/testdata/mageimport/subdir1/mage.go
@@ -1,0 +1,12 @@
+package mage
+
+import "github.com/magefile/mage/mg"
+
+// BuildSubdir Builds stuff.
+func BuildSubdir() {}
+
+// NS is a namespace.
+type NS mg.Namespace
+
+// Deploy deploys stuff.
+func (NS) Deploy() {}

--- a/mage/testdata/mageimport/subdir1/mage.go
+++ b/mage/testdata/mageimport/subdir1/mage.go
@@ -1,12 +1,20 @@
 package mage
 
-import "github.com/magefile/mage/mg"
+import (
+	"fmt"
+
+	"github.com/magefile/mage/mg"
+)
 
 // BuildSubdir Builds stuff.
-func BuildSubdir() {}
+func BuildSubdir() {
+	fmt.Println("buildsubdir")
+}
 
 // NS is a namespace.
 type NS mg.Namespace
 
 // Deploy deploys stuff.
-func (NS) Deploy() {}
+func (NS) Deploy() {
+	fmt.Println("deploy")
+}

--- a/mage/testdata/mageimport/subdir2/mage.go
+++ b/mage/testdata/mageimport/subdir2/mage.go
@@ -1,0 +1,12 @@
+package mage
+
+import "github.com/magefile/mage/mg"
+
+// BuildSubdir2 Builds stuff.
+func BuildSubdir2() {}
+
+// NS is a namespace.
+type NS mg.Namespace
+
+// Deploy2 deploys stuff.
+func (NS) Deploy2() {}

--- a/mage/testdata/mageimport/subdir2/mage.go
+++ b/mage/testdata/mageimport/subdir2/mage.go
@@ -1,12 +1,20 @@
 package mage
 
-import "github.com/magefile/mage/mg"
+import (
+	"fmt"
+
+	"github.com/magefile/mage/mg"
+)
 
 // BuildSubdir2 Builds stuff.
-func BuildSubdir2() {}
+func BuildSubdir2() {
+	fmt.Println("buildsubdir2")
+}
 
 // NS is a namespace.
 type NS mg.Namespace
 
 // Deploy2 deploys stuff.
-func (NS) Deploy2() {}
+func (NS) Deploy2() {
+	fmt.Println("deploy2")
+}

--- a/magefile.go
+++ b/magefile.go
@@ -19,10 +19,6 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-var Aliases = map[string]interface{}{
-	"foo": Foo.Build,
-}
-
 // Runs "go install" for mage.  This generates the version info the binary.
 func Install() error {
 	name := "mage"
@@ -101,10 +97,4 @@ func tag() string {
 func hash() string {
 	hash, _ := sh.Output("git", "rev-parse", "--short", "HEAD")
 	return hash
-}
-
-type Foo mg.Namespace
-
-func (Foo) Build() {
-
 }

--- a/magefile.go
+++ b/magefile.go
@@ -17,17 +17,7 @@ import (
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-
-	// Mage:Import
-	_ "github.com/magefile/mage/zztest"
 )
-
-var MageImports = []string{
-	"github.com/magefile/mage/zztest",
-}
-var MageImportMap = map[string]string{
-	"zz": "github.com/magefile/mage/zztest2",
-}
 
 // Runs "go install" for mage.  This generates the version info the binary.
 func Install() error {

--- a/magefile.go
+++ b/magefile.go
@@ -17,7 +17,17 @@ import (
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+
+	// Mage:Import
+	_ "github.com/magefile/mage/zztest"
 )
+
+var MageImports = []string{
+	"github.com/magefile/mage/zztest",
+}
+var MageImportMap = map[string]string{
+	"zz": "github.com/magefile/mage/zztest2",
+}
 
 // Runs "go install" for mage.  This generates the version info the binary.
 func Install() error {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -38,14 +38,28 @@ type PkgInfo struct {
 
 // Function represented a job function from a mage file
 type Function struct {
-	PkgAlias  string
-	Package   string
-	Name      string
-	Receiver  string
-	IsError   bool
-	IsContext bool
-	Synopsis  string
-	Comment   string
+	PkgAlias   string
+	Package    string
+	ImportPath string
+	Name       string
+	Receiver   string
+	IsError    bool
+	IsContext  bool
+	Synopsis   string
+	Comment    string
+}
+
+// ID returns user-readable information about where this function is defined.
+func (f Function) ID() string {
+	path := "<current>"
+	if f.ImportPath != "" {
+		path = f.ImportPath
+	}
+	receiver := ""
+	if f.Receiver != "" {
+		receiver = f.Receiver + "."
+	}
+	return fmt.Sprintf("%s.%s%s", path, receiver, f.Name)
 }
 
 // TargetName returns the name of the target as it should appear when used from

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -29,9 +29,9 @@ func EnableDebug() {
 // parsing rules.
 type PkgInfo struct {
 	Description string
-	Funcs       []Function
-	DefaultFunc Function
-	Aliases     map[string]Function
+	Funcs       []*Function
+	DefaultFunc *Function
+	Aliases     map[string]*Function
 	Imports     map[string]string
 	RootImports []string
 }
@@ -177,7 +177,7 @@ func setFuncs(p *doc.Package, pi *PkgInfo) {
 		}
 		if typ := funcType(f.Decl.Type); typ != invalidType {
 			debug.Printf("found target %v", f.Name)
-			pi.Funcs = append(pi.Funcs, Function{
+			pi.Funcs = append(pi.Funcs, &Function{
 				Name:      f.Name,
 				Comment:   toOneLine(f.Doc),
 				Synopsis:  sanitizeSynopsis(f),
@@ -205,7 +205,7 @@ func setNamespaces(p *doc.Package, pi *PkgInfo) {
 				continue
 			}
 			debug.Printf("found namespace method %s %s.%s", p.ImportPath, t.Name, f.Name)
-			pi.Funcs = append(pi.Funcs, Function{
+			pi.Funcs = append(pi.Funcs, &Function{
 				Name:      f.Name,
 				Receiver:  t.Name,
 				Comment:   toOneLine(f.Doc),
@@ -427,7 +427,7 @@ func setAliases(p *doc.Package, pi *PkgInfo) {
 				log.Println("warning: aliases declaration is not a map")
 				return
 			}
-			pi.Aliases = map[string]Function{}
+			pi.Aliases = map[string]*Function{}
 			for _, elem := range comp.Elts {
 				kv, ok := elem.(*ast.KeyValueExpr)
 				if !ok {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -78,9 +78,11 @@ func TestParse(t *testing.T) {
 	for _, fn := range expected {
 		found := false
 		for _, infoFn := range info.Funcs {
-			if reflect.DeepEqual(fn, infoFn) {
+			if reflect.DeepEqual(fn, *infoFn) {
 				found = true
 				break
+			} else {
+				t.Logf("%#v", infoFn)
 			}
 		}
 		if !found {

--- a/site/content/importing/_index.en.md
+++ b/site/content/importing/_index.en.md
@@ -1,0 +1,59 @@
++++
+title = "Importing Targets"
+weight = 11
++++
+
+Mage allows you to import targets from another package into the current
+magefile.  This is very useful when you have common targets that you'd like to
+be able to reuse across many repos.
+
+## Imported Package Restrictions
+
+To import targets from another package, that package must *not* be a main
+package.  i.e. it cannot be `package main`.  This is in contrast to a normal
+mage package that must be `package main`.  The reason is that the go tool won't
+let you import a main package.
+
+In addition, all files will be imported, not just those tagged with the
+`//+build mage` build tag.  Again, this is a restriction of the go tool.  Mage
+can build only the `.go` files in the current directory that have the `mage`
+build tag, but when importing code from other directories, it's simply not
+possible.  This means that any exported function (in any file) that matches
+Mage's allowed formats will be picked up as a target. 
+
+Aliases and defaults in the imported package will be ignored. 
+
+Other than these differences, you can write targets in those packages just
+like a normal magefile.
+
+## Two Ways to Import
+
+Importing targets from a package simply requires adding a `// mage:import`
+comment on an import statement in your magefile.  If there is a name after this
+tag, the targets will be imported into what is effectively like a namespace.
+
+```go
+import (
+    // mage:import
+    _ "example.com/me/foobar" 
+    // mage:import build
+    "example.com/me/builder"
+)
+```
+
+The first mage import above will add the targets from the foobar package to the
+root namespace of your current magefile.  Thus, if there's a `func Deploy()` in
+foobar, your magefile will now have a `deploy` target.
+
+The second import above will create a `build` namespace for the targets in the
+`builder` package.  Thus, if there's a `func All()` in builder, your magefile
+will now have a `build:all` target.
+
+Note that you can use imported package targets as dependencies with `mg.Deps`,
+just like any other function works in `mg.Deps`, so you could have
+`mg.Deps(builder.All)`.
+
+If you don't need to actually use the package in your root magefile, simply make
+the import an underscore import like the first import above.
+
+


### PR DESCRIPTION
This is stll a work in progress (needs tests and validation code) but the core works.   What you do is underscore import the package that has the mage targets you want in the current magefile, and then add `// mage:import` as a comment on the import.  Note that the package you import will include all files, not just those with `//+build mage`. This is unfortunately a restriction of the go compiler and not something that I can really get around.

By default mage:import drops the targets into the root namespace of this magefile, but if you'd like to make a namespace for those targets you can do so by adding a namespace after the mage:import statement.  For example, `// mage:import build` would prefix the targets in that
package with `build:`

full example:

```go
// +build mage

import (
    "fmt"

    // targets imported as if they were defined in this file
    // mage:import
    _ "github.com/foo/bar/mage/common" 
   
    // targets imported as if they were in a "build" namespace in this file
    // mage:import build
    _ "github.com/foo/bar/mage/builder"  
)
```

It technically doesn't have to be an underscore import, any import will work, but the other imports will cause "unused import" errors (if they're not used).
