### PR TITLE
Fix mixed package imports

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -447,7 +447,7 @@ func getNamedImports(gocmd string, pkgs map[string]string) ([]*Import, error) {
 }
 
 func getImport(gocmd, importpath, alias string) (*Import, error) {
-	out, err := outputDebug(gocmd, "list", "-tags=mage", "-f", "{{.Dir}}||{{.Name}}", importpath)
+	out, err := outputDebug(gocmd, "list", "-f", "{{.Dir}}||{{.Name}}", importpath)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func Compile(magePath, goCmd, compileTo string, gofiles []string, isDebug bool, 
 		gofiles[i] = filepath.Base(gofiles[i])
 	}
 	debug.Printf("running %s -tag=mage build -o %s %s", goCmd, compileTo, strings.Join(gofiles, " "))
-	c := exec.Command(goCmd, append([]string{"build", "-tags=mage", "-o", compileTo}, gofiles...)...)
+	c := exec.Command(goCmd, append([]string{"build", "-o", compileTo}, gofiles...)...)
 	c.Env = os.Environ()
 	c.Stderr = stderr
 	c.Stdout = stdout

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -128,6 +128,26 @@ func TestListMagefilesLib(t *testing.T) {
 	}
 }
 
+func TestMixedMageImports(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mixed_lib_files",
+		Stdout: stdout,
+		Stderr: stderr,
+		List:   true,
+	}
+	code := Invoke(inv)
+	if code != 0 {
+		t.Errorf("expected to exit with code 0, but got %v, stderr: %s", code, stderr)
+	}
+	expected := "Targets:\n  build    \n"
+	actual := stdout.String()
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
 func TestGoRun(t *testing.T) {
 	c := exec.Command("go", "run", "main.go")
 	c.Dir = "./testdata"

--- a/mage/testdata/mixed_lib_files/magefile.go
+++ b/mage/testdata/mixed_lib_files/magefile.go
@@ -2,4 +2,8 @@
 
 package main
 
-func Build() {}
+import "./subdir"
+
+func Build() {
+	subdir.Build()
+}

--- a/mage/testdata/mixed_lib_files/subdir/magefile.go
+++ b/mage/testdata/mixed_lib_files/subdir/magefile.go
@@ -1,0 +1,5 @@
+// +build mage
+
+package main
+
+func Build() {}

--- a/mage/testdata/mixed_lib_files/subdir/nonmage.go
+++ b/mage/testdata/mixed_lib_files/subdir/nonmage.go
@@ -1,0 +1,3 @@
+package subdir
+
+func Build() {}


### PR DESCRIPTION
When I added mage:imports I added code to run the compile with -tags=mage... that was
a mistake. We don't actually want to do that because if you import code from a
directory which has both magefiles and non-mage files, then it'll fail to compile
if they're different package names.