### PR TITLE
revise mage build instructions for go 1.11

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -16,12 +16,12 @@ and above (possibly even lower versions, but they're not regularly tested).
 Install mage by running 
 
 ```plain
-go get -u -d github.com/magefile/mage
-cd $GOPATH/src/github.com/magefile/mage
+git clone https://github.com/magefile/mage
+cd mage
 go run bootstrap.go
 ```
 
-This will download the code into your GOPATH, and then run the bootstrap script
+This will download the code then run the bootstrap script
 to build mage with version infomation embedded in it.  A normal `go get`
 (without -d) will build the binary correctly, but no version info will be
 embedded.  If you've done this, no worries, just go to


### PR DESCRIPTION
As of Go 1.11, the Mage bootstrap instructions are broken, because `go get -u -d` will leave the source in a read-only `$GOPATH/mod` directory instead of `$GOPATH/src`.  It should be conceptually simpler to clone the repo by hand and go run the bootstrap from there.

Well, simpler, until Go changes how things are built from online sources again..