### PR TITLE
GOOS and GOARCH fixes

### DIFF
--- a/mage/testdata/goos_magefiles/magefile_nonwindows.go
+++ b/mage/testdata/goos_magefiles/magefile_nonwindows.go
@@ -1,0 +1,5 @@
+// +build mage,!windows
+
+package main
+
+func NonWindowsTarget() {}

--- a/mage/testdata/goos_magefiles/magefile_windows.go
+++ b/mage/testdata/goos_magefiles/magefile_windows.go
@@ -1,0 +1,5 @@
+// +build mage
+
+package main
+
+func WindowsTarget() {}

--- a/site/content/compiling/_index.en.md
+++ b/site/content/compiling/_index.en.md
@@ -1,0 +1,41 @@
++++
+title = "Compiling"
+weight = 37
++++
+
+## Mage ignores GOOS and GOARCH for its build
+
+When building the binary for your magefile, mage will ignore the GOOS and GOARCH environment variables and use your current GOOS and GOARCH to ensure the binary that is built can run on your local system.  This way you can set GOOS and GOARCH when you run mage, to have it take effect on the outputs of your magefile, without it also rendering your magefile unrunnable on your local machine.
+
+## Compiling a static binary
+
+If your tasks are not related to compiling Go code, it can be useful to compile
+a static binary which has the mage execution runtime and the tasks compiled in
+such that it can be run on another machine without requiring installation of
+dependencies. To do so, pass the output path to the compile flag. like this:
+
+```plain
+$ mage -compile ./static-output
+```
+
+The compiled binary uses flags just like the mage binary:
+
+```plain
+<cmd_name> [options] [target]
+
+Commands:
+  -l    list targets in this binary
+  -h    show this help
+
+Options:
+  -h    show description of a target
+  -t <string>
+        timeout in duration parsable format (e.g. 5m30s)
+  -v    show verbose output when running targets
+```
+
+## Compiling for a different OS
+
+If you intend to run the binary on another machine with a different OS platform, you may use the -goos and -goarch flags to build the compiled binary for the target platform.  Valid values for these flags may be found here: https://golang.org/doc/install/source#environment.  The OS values are obvious, the GOARCH values most commonly needed will be "amd64" or "386" for 64 for 32 bit versions of common desktop OSes.
+
+Note that if you run -compile with -dir, the -compile target will be *relative to the dir flag*.

--- a/site/content/compiling/_index.en.md
+++ b/site/content/compiling/_index.en.md
@@ -9,10 +9,10 @@ When building the binary for your magefile, mage will ignore the GOOS and GOARCH
 
 ## Compiling a static binary
 
-If your tasks are not related to compiling Go code, it can be useful to compile
-a static binary which has the mage execution runtime and the tasks compiled in
-such that it can be run on another machine without requiring installation of
-dependencies. To do so, pass the output path to the compile flag. like this:
+It can be useful to compile a static binary which has the mage execution runtime
+and the tasks compiled in such that it can be run on another machine without
+requiring any dependencies. To do so, pass the output path to the compile flag.
+like this:
 
 ```plain
 $ mage -compile ./static-output
@@ -34,8 +34,8 @@ Options:
   -v    show verbose output when running targets
 ```
 
-## Compiling for a different OS
+## Compiling for a different OS -goos and -goarch
 
-If you intend to run the binary on another machine with a different OS platform, you may use the -goos and -goarch flags to build the compiled binary for the target platform.  Valid values for these flags may be found here: https://golang.org/doc/install/source#environment.  The OS values are obvious, the GOARCH values most commonly needed will be "amd64" or "386" for 64 for 32 bit versions of common desktop OSes.
+If you intend to run the binary on another machine with a different OS platform, you may use the `-goos` and `-goarch` flags to build the compiled binary for the target platform.  Valid values for these flags may be found here: https://golang.org/doc/install/source#environment.  The OS values are obvious (except darwin=MacOS), the GOARCH values most commonly needed will be "amd64" or "386" for 64 for 32 bit versions of common desktop OSes.
 
-Note that if you run -compile with -dir, the -compile target will be *relative to the dir flag*.
+Note that if you run `-compile` with `-dir`, the `-compile` target will be *relative to the magefile dir*.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -66,17 +66,19 @@ Commands:
 
 Options:
   -d <string> 
-          run magefiles in the given directory (default ".")
-  -debug  turn on debug messages
-  -h      show description of a target
-  -f      force recreation of compiled magefile
-  -keep   keep intermediate mage files around after running
+            run magefiles in the given directory (default ".")
+  -debug    turn on debug messages
+  -h        show description of a target
+  -f        force recreation of compiled magefile
+  -keep     keep intermediate mage files around after running
   -gocmd <string>
-          use the given go binary to compile the output (default: "go")
+		    use the given go binary to compile the output (default: "go")
+  -goos     sets the GOOS for the binary created by -compile (default: current OS)
+  -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
   -t <string>
-          timeout in duration parsable format (e.g. 5m30s)
-  -v      show verbose output when running mage targets
-```
+            timeout in duration parsable format (e.g. 5m30s)
+  -v        show verbose output when running mage targets
+  ```
 
 ## Why?
 
@@ -90,17 +92,6 @@ Windows.  Go is superior to bash for any non-trivial task involving branching, l
 that's not just straight line execution of commands.  And if your project is written in Go, why
 introduce another language as idiosyncratic as bash?  Why not use the language your contributors are
 already comfortable with?
-
-## Compiling a static binary
-
-If your tasks are not related to compiling Go code, it can be useful to compile a binary which has
-the mage execution runtime and the tasks compiled in such that it can be run on another machine
-without requiring installation of dependencies. To do so, pass the output path to the compile flag.
-like this:
-
-```plain
-$ mage -compile ./static-output
-```
 
 ## Code
 


### PR DESCRIPTION
this fixes #169 - mage now ignores GOOS and GOARCH in the environment
when building its own binaries.  The exception is if you use -goos or -goarch
when running -compile.