### PR TITLE
fix one line imports as mage:imports

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -166,3 +166,24 @@ func TestMageImportsAliasToNS(t *testing.T) {
 		t.Fatalf("expected: %q got: %q", expected, actual)
 	}
 }
+
+func TestMageImportsOneLine(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport/oneline",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"build"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "build\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
+	}
+}

--- a/mage/testdata/mageimport/oneline/magefile.go
+++ b/mage/testdata/mageimport/oneline/magefile.go
@@ -1,0 +1,6 @@
+// +build mage
+
+package main
+
+// mage:import
+import _ "github.com/magefile/mage/mage/testdata/mageimport/oneline/other"

--- a/mage/testdata/mageimport/oneline/other/other.go
+++ b/mage/testdata/mageimport/oneline/other/other.go
@@ -1,0 +1,7 @@
+package other
+
+import "fmt"
+
+func Build() {
+	fmt.Println("build")
+}


### PR DESCRIPTION
```go
// mage:import
import "github.com/example.com/foo"
```
This used to not be recognized as a mage import, now it works.  The trick is that the comment above is not on the package declaration, but on the declaration as a whole. 

fixes #194 



