### PR TITLE
Pass MAGEFILE_GOCMD to compiled binary

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -604,6 +604,9 @@ func RunCompiled(inv Invocation, exePath string, errlog *log.Logger) int {
 	if inv.Debug {
 		c.Env = append(c.Env, "MAGEFILE_DEBUG=1")
 	}
+	if inv.GoCmd != "" {
+		c.Env = append(c.Env, fmt.Sprintf("MAGEFILE_GOCMD=%s", inv.GoCmd))
+	}
 	if inv.Timeout > 0 {
 		c.Env = append(c.Env, fmt.Sprintf("MAGEFILE_TIMEOUT=%s", inv.Timeout.String()))
 	}


### PR DESCRIPTION
Pass the `MAGEFILE_GOCMD` environment variable into the compiled binary
when running with `-gocmd` set.

Testing Done:

- Validated that running `mage -debug -gocmd <go-runtime> <target>`
  properly sets the environment variable `MAGEFILE_GOCMD=<go-runtime>`
  into the temporary binary.
- Validated that compiled magefiles will not persist the initial
  `-gocmd` when executing - though this is still toggleable by providing
  the environment variable manually.

fixes #208