### PR TITLE
Sort target list when using mage:import

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -22,11 +22,11 @@ func TestMageImportsList(t *testing.T) {
 	actual := stdout.String()
 	expected := `
 Targets:
-  root               
-  zz:nS:deploy2*     deploys stuff.
-  zz:buildSubdir2    Builds stuff.
-  nS:deploy          deploys stuff.
   buildSubdir        Builds stuff.
+  nS:deploy          deploys stuff.
+  root               
+  zz:buildSubdir2    Builds stuff.
+  zz:nS:deploy2*     deploys stuff.
 
 * default target
 `[1:]


### PR DESCRIPTION
I was trying out the `mage:import` feature which is wonderful in helping reduce duplication in our monorepo. I thought it would nice to have all targets sorted when using this feature.