### PR TITLE
Add copying helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ mage_output_file.go
 # Goland
 .idea
 *.iml
+
+# Vim
+*.sw[op]
+*.vim
+
+# GNU Screen
+.screenrc
+

--- a/sh/helpers.go
+++ b/sh/helpers.go
@@ -87,18 +87,31 @@ func CopyDir(dst, src string) error {
 // are:
 //
 // * (FAIL) No source.
+//
 // * (FAIL) Non existent source.
+//
 // * (PASS) File to non existent file.
+//
 // * (FAIL) File to more than one non existent elements in destination.
+//
 // * (PASS) File to file.
+//
 // * (PASS) File to directory.
+//
 // * (FAIL) Directory to file.
+//
 // * (PASS) Directory to non existent directory.
+//
 // * (FAIL) Directory to more than one non existent elements in destination.
+//
 // * (PASS) Directory to directory.
+//
 // * (FAIL) Directory to itself.
+//
 // * (FAIL) Multiple elements to file.
+//
 // * (PASS) Multiple elements to directory.
+//
 // * (FAIL) Bad permissions.
 func Cp(dst string, src ...string) error {
 	dfi, err := os.Stat(dst)

--- a/sh/helpers.go
+++ b/sh/helpers.go
@@ -1,9 +1,12 @@
 package sh
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 // Rm removes the given file or directory even if non-empty. It will not return
@@ -35,5 +38,155 @@ func Copy(dst string, src string) error {
 	if err != nil {
 		return fmt.Errorf(`error copying %s to %s: %v`, src, dst, err)
 	}
+	return nil
+}
+
+// CopyDir copies recursively the source directory content to the destination,
+// overwriting files in the destination if necessary. Errors will be wrapped
+// into a single error.
+func CopyDir(dst, src string) error {
+	sfi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if !sfi.IsDir() {
+		return fmt.Errorf("cannot use file %v as source", src)
+	}
+
+	srcabs, err := filepath.Abs(src)
+	if err != nil {
+		return err
+	}
+
+	dstabs, err := filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
+
+	if strings.HasPrefix(dstabs, srcabs) {
+		return fmt.Errorf("cannot copy directory %v into itself", dst)
+	}
+
+	dfi, err := os.Stat(dst)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(dst, sfi.Mode()); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	} else if !dfi.IsDir() {
+		msg := "cannot overwrite non-directory %v with directory %v"
+		return fmt.Errorf(msg, dst, src)
+	}
+
+	return copyDir(dst, src)
+}
+
+// Cp behaves like the Unix command cp with -rf flags. The possible scenarios
+// are:
+//
+// * (FAIL) No source.
+// * (FAIL) Non existent source.
+// * (PASS) File to non existent file.
+// * (FAIL) File to more than one non existent elements in destination.
+// * (PASS) File to file.
+// * (PASS) File to directory.
+// * (FAIL) Directory to file.
+// * (PASS) Directory to non existent directory.
+// * (FAIL) Directory to more than one non existent elements in destination.
+// * (PASS) Directory to directory.
+// * (FAIL) Directory to itself.
+// * (FAIL) Multiple elements to file.
+// * (PASS) Multiple elements to directory.
+// * (FAIL) Bad permissions.
+func Cp(dst string, src ...string) error {
+	dfi, err := os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	n := len(src)
+
+	switch {
+	case n == 0:
+		return errors.New("missing source")
+	case n > 1 && dfi == nil:
+		return fmt.Errorf("%v doesn't exists", dst)
+	case n > 1 && !dfi.IsDir():
+		return fmt.Errorf("%v is not a directory", dst)
+	}
+
+	var errs []string
+	var fn func(string, string) error
+
+	for _, entry := range src {
+		dst := dst
+
+		sfi, err := os.Stat(entry)
+		if err != nil {
+			return err
+		}
+
+		if dfi != nil && dfi.IsDir() {
+			dst = filepath.Join(dst, sfi.Name())
+		}
+
+		if sfi.IsDir() {
+			fn = CopyDir
+		} else {
+			fn = Copy
+		}
+
+		if err := fn(dst, entry); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+
+	return nil
+}
+
+func copyDir(dst, src string) error {
+	var errs []string
+
+	fn := func(srcpath string, fi os.FileInfo, err error) error {
+		if src == srcpath {
+			return nil
+		}
+
+		if err != nil {
+			errs = append(errs, err.Error())
+			return nil
+		}
+
+		dst := filepath.Clean(strings.Replace(srcpath, src, dst, 1))
+
+		if fi.IsDir() {
+			if err := os.Mkdir(dst, fi.Mode()); err != nil {
+				errs = append(errs, err.Error())
+				return nil
+			}
+		} else {
+			if err := Copy(dst, srcpath); err != nil {
+				errs = append(errs, err.Error())
+				return nil
+			}
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(src, fn); err != nil {
+		return err
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+
 	return nil
 }

--- a/sh/helpers.go
+++ b/sh/helpers.go
@@ -1,7 +1,6 @@
 package sh
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,161 +18,100 @@ func Rm(path string) error {
 	return fmt.Errorf(`failed to remove %s: %v`, path, err)
 }
 
-// Copy robustly copies the source file to the destination, overwriting the destination if necessary.
-func Copy(dst string, src string) error {
+// Copy robustly copies the source file to the destination, overwriting the
+// destination if necessary.
+func Copy(dst, src string) error {
 	finfo, err := os.Stat(src)
 	if err != nil {
-		return fmt.Errorf(`can't stat %s: %v`, src, err)
+		return fmt.Errorf("can't stat %s: %v", src, err)
 	}
 
 	if err = copyFile(dst, src, finfo); err != nil {
-		return fmt.Errorf(`can't copy %s to %s: %v`, src, dst, err)
+		return fmt.Errorf("can't copy %s to %s: %v", src, dst, err)
 	}
 
 	return nil
 }
 
-// Cp behaves like the Unix command cp with -rf flags. The possible scenarios
-// are:
-//
-// * [FAIL] No source.
-//
-// * [FAIL] Non existent source.
-//
-// * [FAIL] Multiple non existent elements in destination path.
-//
-// * [FAIL] Bad permissions.
-//
-// * [PASS] File to non existent file, dst will be created with the same
-// content as src.
-//
-// * [PASS] File to file, dst will be overwritten by src.
-//
-// * [PASS] File to directory, dst will be a file inside dst with the same base
-// name as src.
-//
-// * [FAIL] Directory to file.
-//
-// * [PASS] Directory to non existent directory, dst will be created with the
-// same content as src.
-//
-// * [PASS] Directory to directory, dst will be a directory inside dst with the
-// same base name as src.
-//
-// * [FAIL] Directory to itself.
-//
-// * [FAIL] Multiple elements to file.
-//
-// * [FAIL] Multiple elements to non existent directory.
-//
-// * [PASS] Multiple elements to directory, any src elements will be
-// created/overwritten in dst.
-func Cp(dst string, src ...string) error {
-	dfi, err := os.Stat(dst)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	n := len(src)
-
-	switch {
-	case n == 0:
-		return errors.New("missing source")
-	case n == 1 && dfi != nil && dfi.IsDir():
-		dst = filepath.Join(dst, filepath.Base(src[0]))
-	case n > 1 && dfi == nil:
-		return fmt.Errorf("%v doesn't exists", dst)
-	case n > 1 && !dfi.IsDir():
-		return fmt.Errorf("%v is not a directory", dst)
-	}
-
-	var errs []string
-	var fn func(string, string, os.FileInfo) error
-
-	for _, entry := range src {
-		sfi, err := os.Stat(entry)
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		if sfi.IsDir() {
-			fn = copyDir
-		} else {
-			fn = copyFile
-		}
-
-		dst := dst
-		if n > 1 {
-			dst = filepath.Join(dst, sfi.Name())
-		}
-
-		if err := fn(dst, entry, sfi); err != nil {
-			errs = append(errs, err.Error())
-		}
-	}
-
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n"))
-	}
-
-	return nil
-}
-
-func copyDir(dst, src string, sfi os.FileInfo) error {
-	srcabs, err := filepath.Abs(src)
-	if err != nil {
-		return err
-	}
-
-	dstabs, err := filepath.Abs(dst)
-	if err != nil {
-		return err
-	}
-
-	if strings.HasPrefix(dstabs, srcabs) {
-		return fmt.Errorf("cannot copy directory %v into itself (%s)", src, dst)
-	}
-
-	if err := os.Mkdir(dst, sfi.Mode()); err != nil {
-		return err
-	}
-
-	var errs []string
-
+// CopyDir copies the source directory content to given destination.
+// Destination  must exist.
+func CopyDir(dst, src string) error {
 	fn := func(srcpath string, fi os.FileInfo, err error) error {
-		if src == srcpath {
-			return nil
+		if err != nil {
+			return err
 		}
 
-		if err != nil {
-			errs = append(errs, err.Error())
-			return nil
+		if srcpath == src {
+			return filepath.SkipDir
 		}
 
 		dst := filepath.Clean(strings.Replace(srcpath, src, dst, 1))
 
 		if fi.IsDir() {
-			if err := os.Mkdir(dst, fi.Mode()); err != nil {
-				errs = append(errs, err.Error())
-				return nil
+			mkerr := os.Mkdir(dst, fi.Mode())
+			if os.IsExist(mkerr) {
+				return os.Chmod(dst, fi.Mode())
 			}
-		} else {
-			if err := copyFile(dst, srcpath, fi); err != nil {
-				errs = append(errs, err.Error())
-				return nil
-			}
+
+			return mkerr
 		}
 
-		return nil
+		return copyFile(dst, srcpath, fi)
 	}
 
 	if err := filepath.Walk(src, fn); err != nil {
-		return err
+		return fmt.Errorf("can't copy %s to %s: %v", src, dst, err)
 	}
 
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n"))
+	return nil
+}
+
+// CopyDirAll copies the source directory content to given destination. If
+// destination doesn't exist, it will be created
+func CopyDirAll(dst, src string) error {
+	finfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("can't stat %s: %v", src, err)
+	}
+
+	if err := os.MkdirAll(dst, finfo.Mode()); err != nil {
+		return fmt.Errorf("can't create %s: %v", dst, err)
+	}
+
+	return CopyDir(dst, src)
+}
+
+// CopyAny copies the source elements to the given destination. Destination
+// must be a directory.
+func CopyAny(dst string, src ...string) error {
+	dfi, err := os.Stat(dst)
+	if err != nil {
+		return fmt.Errorf("can't stat %s: %v", dst, err)
+	}
+
+	if !dfi.IsDir() {
+		return fmt.Errorf("can't use %s as destination", dst)
+	}
+
+	for _, el := range src {
+		sfi, elerr := os.Stat(el)
+		if elerr != nil {
+			return fmt.Errorf("can't stat %s: %v", el, elerr)
+		}
+
+		dst := filepath.Join(dst, sfi.Name())
+
+		if sfi.IsDir() {
+			if elerr = CopyDirAll(dst, el); elerr != nil {
+				return elerr
+			}
+
+			continue
+		}
+
+		if elerr = copyFile(dst, el, sfi); elerr != nil {
+			return elerr
+		}
 	}
 
 	return nil

--- a/sh/helpers_test.go
+++ b/sh/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/magefile/mage/sh"
@@ -73,6 +74,252 @@ func TestHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("sh/copydir", func(t *testing.T) {
+		cpddir := filepath.Join(mytmpdir, "copydir-dir")
+		if cerr := os.Mkdir(cpddir, 0744); cerr != nil {
+			t.Fatalf("can't create CopyDir test directory: %v", cerr)
+		}
+
+		// Directory to non existent directory.
+
+		neDir := filepath.Join(mytmpdir, "copydir-non-existent-directory")
+		if cerr := sh.CopyDir(neDir, cpddir); cerr != nil {
+			msg := "test directory copy from %s to %s failed: %v"
+			t.Errorf(msg, cpddir, neDir, cerr)
+		}
+
+		if cerr := compareDirs(cpddir, neDir); cerr != nil {
+			t.Errorf("test directory copy verification failed: %v", cerr)
+		}
+
+		// Directory to directory.
+
+		if cerr := sh.CopyDir(neDir, cpddir); cerr != nil {
+			msg := "test directory copy from %s to %s failed: %v"
+			t.Errorf(msg, cpddir, neDir, cerr)
+		}
+
+		ndir := filepath.Join(neDir, "copydir-dir")
+		if cerr := compareDirs(cpddir, ndir); cerr != nil {
+			t.Errorf("test directory copy verification failed: %v", cerr)
+		}
+	})
+
+	t.Run("sh/copydir/ne", func(t *testing.T) {
+		ned := filepath.Join(mytmpdir, "copydir-ne-dir")
+		if cerr := sh.CopyDir(destname, ned); cerr == nil {
+			t.Errorf("sh.CopyDir succeeded copying nonexistent directory %s", ned)
+		}
+	})
+
+	t.Run("sh/copydir/files", func(t *testing.T) {
+		if cerr := sh.CopyDir(mytmpdir, srcname); cerr == nil {
+			t.Error("sh.CopyDir succeeded using file as source")
+		}
+
+		otherd := filepath.Join(mytmpdir, "copydir-files-dir")
+		if cerr := os.Mkdir(otherd, 0744); cerr != nil {
+			t.Fatalf("can't create other test directory: %v", cerr)
+		}
+
+		if cerr := sh.CopyDir(destname, otherd); cerr == nil {
+			t.Error("sh.CopyDir succeeded using file as destination")
+		}
+	})
+
+	t.Run("sh/copydir/d2itself", func(t *testing.T) {
+		ii := filepath.Join(mytmpdir, "copydir-d2itself-dir")
+		if cerr := sh.CopyDir(ii, mytmpdir); cerr == nil {
+			t.Error("sh.CopyDir succeeded copying folders into itself")
+		}
+	})
+
+	t.Run("sh/copydir/lne", func(t *testing.T) {
+		otherd := filepath.Join(mytmpdir, "copydir-lne-dir")
+		if cerr := os.Mkdir(otherd, 0744); cerr != nil {
+			t.Fatalf("can't create other test directory: %v", cerr)
+		}
+
+		ned := filepath.Join(mytmpdir, "long", "non", "existent", "directory")
+		if cerr := sh.CopyDir(ned, otherd); cerr == nil {
+			msg := "sh.CopyDir succeeded copying to a long nonexistent directory %s"
+			t.Errorf(msg, ned)
+		}
+	})
+
+	t.Run("sh/cp", func(t *testing.T) {
+		cpdir := filepath.Join(mytmpdir, "cp-dir")
+		if cerr := os.Mkdir(cpdir, 0744); cerr != nil {
+			t.Fatalf("can't create cp test directory: %v", cerr)
+		}
+
+		// File to non existent file.
+
+		cpdestname := filepath.Join(cpdir, "cp-test.txt")
+		if cerr := sh.Cp(cpdestname, srcname); cerr != nil {
+			msg := "test file copy from %s to %s failed: %v"
+			t.Errorf(msg, srcname, cpdestname, cerr)
+		}
+
+		if cerr := compareFiles(srcname, cpdestname); cerr != nil {
+			t.Errorf("test file copy verification failed: %v", cerr)
+		}
+
+		// File to file.
+
+		otherf := filepath.Join(mytmpdir, "other.txt")
+		if cerr := ioutil.WriteFile(otherf, []byte("Content"), 0644); err != nil {
+			t.Fatalf("can't create other test file %s: %v", otherf, cerr)
+		}
+
+		if cerr := sh.Cp(cpdestname, otherf); cerr != nil {
+			msg := "test file copy from %s to %s failed: %v"
+			t.Errorf(msg, otherf, cpdestname, cerr)
+		}
+
+		if cerr := compareFiles(otherf, cpdestname); cerr != nil {
+			t.Errorf("test file copy verification failed: %v", cerr)
+		}
+
+		// File to directory.
+
+		if cerr := sh.Cp(cpdir, srcname); cerr != nil {
+			msg := "test file copy from %s to %s/ failed: %v"
+			t.Errorf(msg, srcname, cpdir, cerr)
+		}
+
+		cpdestname = filepath.Join(cpdir, filepath.Base(srcname))
+		if cerr := compareFiles(srcname, cpdestname); cerr != nil {
+			t.Errorf("test file copy verification failed: %v", cerr)
+		}
+
+		// Directory to non existent directory.
+
+		neDir := filepath.Join(mytmpdir, "cp-non-existent-directory")
+		if cerr := sh.Cp(neDir, cpdir); cerr != nil {
+			msg := "test directory copy from %s to %s failed: %v"
+			t.Errorf(msg, cpdir, neDir, cerr)
+		}
+
+		if cerr := compareDirs(cpdir, neDir); cerr != nil {
+			t.Errorf("test directory copy verification failed: %v", cerr)
+		}
+
+		// Directory to directory.
+
+		if cerr := sh.Cp(cpdir, neDir); cerr != nil {
+			msg := "test directory copy from %s to %s failed: %v"
+			t.Errorf(msg, neDir, cpdir, cerr)
+		}
+
+		ndir := filepath.Join(cpdir, "cp-non-existent-directory")
+		if cerr := compareDirs(neDir, ndir); cerr != nil {
+			t.Errorf("test directory copy verification failed: %v", cerr)
+		}
+
+		// Multiple elements to directory.
+
+		mdir := filepath.Join(mytmpdir, "cp-multiple-elements")
+		if cerr := os.Mkdir(mdir, 0744); cerr != nil {
+			t.Fatalf("can't create multiple type test directory: %v", cerr)
+		}
+
+		if cerr := sh.Cp(mdir, cpdir, srcname, destname); cerr != nil {
+			msg := "test multiple copy to %s failed: %v"
+			t.Errorf(msg, mdir, cerr)
+		}
+
+		ndir = filepath.Join(mdir, "cp-dir")
+		if cerr := compareDirs(cpdir, ndir); cerr != nil {
+			t.Errorf("test directory copy verification failed: %v", cerr)
+		}
+
+		nfile := filepath.Join(mdir, "test1.txt")
+		if cerr := compareFiles(srcname, nfile); cerr != nil {
+			t.Errorf("test file copy verification failed: %v", cerr)
+		}
+
+		nfile = filepath.Join(mdir, "test2.txt")
+		if cerr := compareFiles(destname, nfile); cerr != nil {
+			t.Errorf("test file copy verification failed: %v", cerr)
+		}
+	})
+
+	t.Run("sh/cp/ns", func(t *testing.T) {
+		if cerr := sh.Cp(destname); cerr == nil {
+			t.Error("sh.Cp succeeded without sources")
+		}
+	})
+
+	t.Run("sh/cp/ne", func(t *testing.T) {
+		nef := filepath.Join(mytmpdir, "cp_file_not_exist.txt")
+		if cerr := sh.Cp(destname, nef); cerr == nil {
+			t.Errorf("sh.Cp succeeded copying nonexistent file %s", nef)
+		}
+	})
+
+	t.Run("sh/cp/f2lne", func(t *testing.T) {
+		ned := filepath.Join(mytmpdir, "long", "non", "existent", "directory")
+		if cerr := sh.Cp(ned, srcname); cerr == nil {
+			msg := "sh.Cp succeeded copying to a long nonexistent directory %s"
+			t.Errorf(msg, ned)
+		}
+	})
+
+	t.Run("sh/cp/d2f", func(t *testing.T) {
+		otherd := filepath.Join(mytmpdir, "cp-d2f-dir")
+		if cerr := os.Mkdir(otherd, 0744); cerr != nil {
+			t.Fatalf("can't create other test directory: %v", cerr)
+		}
+
+		if cerr := sh.Cp(destname, otherd); cerr == nil {
+			t.Error("sh.Cp replaces files with folders")
+		}
+	})
+
+	t.Run("sh/cp/d2lne", func(t *testing.T) {
+		otherd := filepath.Join(mytmpdir, "cp-d2lne-dir")
+		if cerr := os.Mkdir(otherd, 0744); cerr != nil {
+			t.Fatalf("can't create other test directory: %v", cerr)
+		}
+
+		ned := filepath.Join(mytmpdir, "long", "non", "existent", "directory")
+		if cerr := sh.Cp(ned, otherd); cerr == nil {
+			msg := "sh.Cp succeeded copying to a long nonexistent directory %s"
+			t.Errorf(msg, ned)
+		}
+	})
+
+	t.Run("sh/cp/dne", func(t *testing.T) {
+		ned := filepath.Join(mytmpdir, "cp_dir_not_exist")
+
+		if cerr := sh.Cp(ned, srcname, srcname); cerr == nil {
+			t.Errorf("sh.Cp succeeded copying to nonexistent destination %s", ned)
+		}
+	})
+
+	t.Run("sh/cp/m2f", func(t *testing.T) {
+		if cerr := sh.Cp(destname, srcname, srcname); cerr == nil {
+			t.Error("sh.Cp succeeded copying multiple elements to file")
+		}
+	})
+
+	t.Run("sh/cp/forbidden", func(t *testing.T) {
+		fd, err := ioutil.TempDir("", "mage-forbidden")
+		if err != nil {
+			t.Fatalf("can't create test directory: %v", err)
+		}
+
+		forbidden := filepath.Join(fd, "forbidden")
+		if cerr := os.Mkdir(forbidden, 0000); cerr != nil {
+			t.Fatalf("can't create a forbidden directory: %v", cerr)
+		}
+
+		if cerr := sh.Cp(forbidden, mytmpdir); cerr == nil {
+			t.Error("sh.Cp succeeded copying elements to forbidden folder")
+		}
+	})
+
 	// While we've got a temporary directory, test how forgiving sh.Rm is
 	t.Run("sh/rm/ne", func(t *testing.T) {
 		nef := filepath.Join(mytmpdir, "file_not_exist.txt")
@@ -118,4 +365,21 @@ func TestHelpers(t *testing.T) {
 		}
 	})
 
+}
+
+func compareDirs(src, dst string) error {
+	fn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		dstfile := filepath.Clean(strings.Replace(path, src, dst, 1))
+		return compareFiles(path, dstfile)
+	}
+
+	return filepath.Walk(src, fn)
 }


### PR DESCRIPTION
Since the sh.Copy helper just support one file operations, copying directories or multiple file may require help from the OS, which brings compatibility issues (one of the main reasons why we don't use Make). This PR aims to add the following helpers:

* `sh.CopyDir`: copies source directory content to the given destination. This will fail if destination doesn't exist.
* `sh.CopyDirAll`: same as above, but creates the destination directory if it doesn't exist.
* `sh.CopyAny`: copies the source elements to the given destination. Destination must be a directory.

Resolves: #211