### PR TITLE
Added support for per target CLI flags/params

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -193,7 +193,7 @@ func Parse(stderr, stdout io.Writer, args []string) (inv Invocation, cmd Command
 
 	fs.Usage = func() {
 		fmt.Fprint(stdout, `
-mage [options] [target]
+mage [options] [target] [<flags>]
 
 Mage is a make-like command runner.  See https://magefile.org for full docs.
 
@@ -207,19 +207,27 @@ Commands:
   -version  show version info for the mage binary
 
 Options:
-  -d <string> 
+  -d <string>
             run magefiles in the given directory (default ".")
   -debug    turn on debug messages
   -h        show description of a target
   -f        force recreation of compiled magefile
   -keep     keep intermediate mage files around after running
   -gocmd <string>
-		    use the given go binary to compile the output (default: "go")
+            use the given go binary to compile the output (default: "go")
   -goos     sets the GOOS for the binary created by -compile (default: current OS)
   -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
   -t <string>
             timeout in duration parsable format (e.g. 5m30s)
   -v        show verbose output when running mage targets
+
+Flags (per target, optional), supported formats:
+  --        stop processing any further flags
+  -f -flag --f --flag
+            boolean flags only
+  -f=value -flag=value --f=value --flag=value
+            boolean, integer, string flags
+            note: file paths passed as values has to be wrapped in quotes
 `[1:])
 	}
 	err = fs.Parse(args)

--- a/mage/template.go
+++ b/mage/template.go
@@ -246,10 +246,6 @@ Options:
 			if re.FindString(arg) == "" {
 				unknown = append(unknown, arg)
 			}
-			if prevTarget == "" {
-				logger.Printf("Argument for non-existent target: %q\n", arg)
-				os.Exit(1)
-			}
 			// all mage targets originates in main. package e.g.: for target "help" we will set it as "main.help"
 			args.Args[i] = MageTargetArgsPrefix + "main." + prevTarget + ":" + arg
 		} else {

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -78,5 +78,8 @@ type Namespace struct{}
 // GetFlagsFromContext - Helper function
 // for extracting flags from context of a target
 func GetFlagsFromContext(ctx context.Context) []string {
-	return ctx.Value("flags").([]string)
+	if ctx != nil && ctx.Value("flags") != nil {
+		return ctx.Value("flags").([]string)
+	}
+	return []string{}
 }

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -1,11 +1,11 @@
 package mg
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 )
 
 // CacheEnv is the environment variable that users may set to change the
@@ -27,12 +27,6 @@ const GoCmdEnv = "MAGEFILE_GOCMD"
 // IgnoreDefaultEnv is the environment variable that indicates the user requested
 // to ignore the default target specified in the magefile.
 const IgnoreDefaultEnv = "MAGEFILE_IGNOREDEFAULT"
-
-// MageTargetArgsPrefix -
-const MageTargetArgsPrefix = "mage-target-args:"
-
-// MageStopProcArgsPrefix -
-const MageStopProcArgsPrefix = "mage-stop:"
 
 // Verbose reports whether a magefile was run with the verbose flag.
 func Verbose() bool {
@@ -81,71 +75,8 @@ func CacheDir() string {
 // Namespace allows for the grouping of similar commands
 type Namespace struct{}
 
-// GetArgsForTarget returns array of arguments passed to given target from CLI,
-// this array can be then processed by flags package by each target's code
-// This function simplify the way in which you can obtain per target CLI args,
-// without the need of calling this function cli args can be obtained using os.Args
-// but those are encoded in the following format:
-//-----------------------------------------------
-// mage-target-args:main.target:--flag=value
-// where:
-// mage-target-args: - prefix added to non target arguments (args not matching any target or alias name)
-// main.target:      - prefix based on target name, allows to indentify per target args
-// --flag=value      - bash style flag in -f or --flag format
-// value             - can be boolean, string, integer with or without quotes, for file paths
-//                     passed as values please use single quotes to wrap it
-//-----------------------------------------------------------------------------
-// supported flags formats are:
-//-----------------------------
-// --                                          : stop processing any further arguments
-// -f --f -flag --flag                         : boolean flags only
-// -f=value --f=value -flag=value --flag=value : boolean, integer, string flags
-// f=value flag=value                          : boolean, integer, string flags (read above below note)
-//-----------------------------------------------------------------------------
-// Note: for args passed in format: var=value or v=value there is implicit
-// string "--" added at the beginning of it, this is to satisfy flags package
-//-----------------------------------------------------------------------------
-func GetArgsForTarget() []string {
-	var args []string
-	//--------------------------------------------
-	// Get info about the name of calling function
-	// by checking callstack using runtime package
-	// Then use this information to identify cli
-	// args for given target (calling function)
-	//--------------------------------------------
-	programCounter := make([]uintptr, 15)
-	entriesCount := runtime.Callers(2, programCounter)
-	frames := runtime.CallersFrames(programCounter[:entriesCount])
-	frame, _ := frames.Next()
-	// add ":" to the name of calling function, to form target prefix
-	callingFunction := strings.ToLower(frame.Function) + ":"
-	//--------------------------------------------
-	// Loop trough all os.Args and check it's prefixes
-	args = []string{}
-	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, MageStopProcArgsPrefix) {
-			// if we found "mage-stop:" prefix then don't
-			// process any more args, and return what has
-			// been already collected
-			return args
-		}
-		// first, look for args with prefix mage-target-args:
-		if strings.HasPrefix(arg, MageTargetArgsPrefix) {
-			arg = strings.TrimPrefix(arg, MageTargetArgsPrefix)
-			// then, look for args with prefix main.callingFunction
-			if strings.HasPrefix(arg, callingFunction) {
-				arg = strings.TrimPrefix(arg, callingFunction)
-				if !strings.HasPrefix(arg, "-") {
-					// if given arg is missing "-" prefix (so it's in format var=value)
-					// then we have to implicitly append "--" in front of it
-					// in order to satisfy flags package
-					arg = "--" + arg
-				}
-				// here we append raw flag without any prefixes added earlier
-				// this can be easily parsed then by flags by each individial target
-				args = append(args, arg)
-			}
-		}
-	}
-	return args
+// GetFlagsFromContext - Helper function
+// for extracting flags from context of a target
+func GetFlagsFromContext(ctx context.Context) []string {
+	return ctx.Value("flags").([]string)
 }

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 )
 
 // CacheEnv is the environment variable that users may set to change the
@@ -26,6 +27,12 @@ const GoCmdEnv = "MAGEFILE_GOCMD"
 // IgnoreDefaultEnv is the environment variable that indicates the user requested
 // to ignore the default target specified in the magefile.
 const IgnoreDefaultEnv = "MAGEFILE_IGNOREDEFAULT"
+
+// MageTargetArgsPrefix -
+const MageTargetArgsPrefix = "mage-target-args:"
+
+// MageStopProcArgsPrefix -
+const MageStopProcArgsPrefix = "mage-stop:"
 
 // Verbose reports whether a magefile was run with the verbose flag.
 func Verbose() bool {
@@ -73,3 +80,72 @@ func CacheDir() string {
 
 // Namespace allows for the grouping of similar commands
 type Namespace struct{}
+
+// GetArgsForTarget returns array of arguments passed to given target from CLI,
+// this array can be then processed by flags package by each target's code
+// This function simplify the way in which you can obtain per target CLI args,
+// without the need of calling this function cli args can be obtained using os.Args
+// but those are encoded in the following format:
+//-----------------------------------------------
+// mage-target-args:main.target:--flag=value
+// where:
+// mage-target-args: - prefix added to non target arguments (args not matching any target or alias name)
+// main.target:      - prefix based on target name, allows to indentify per target args
+// --flag=value      - bash style flag in -f or --flag format
+// value             - can be boolean, string, integer with or without quotes, for file paths
+//                     passed as values please use single quotes to wrap it
+//-----------------------------------------------------------------------------
+// supported flags formats are:
+//-----------------------------
+// --                                          : stop processing any further arguments
+// -f --f -flag --flag                         : boolean flags only
+// -f=value --f=value -flag=value --flag=value : boolean, integer, string flags
+// f=value flag=value                          : boolean, integer, string flags (read above below note)
+//-----------------------------------------------------------------------------
+// Note: for args passed in format: var=value or v=value there is implicit
+// string "--" added at the beginning of it, this is to satisfy flags package
+//-----------------------------------------------------------------------------
+func GetArgsForTarget() []string {
+	var args []string
+	//--------------------------------------------
+	// Get info about the name of calling function
+	// by checking callstack using runtime package
+	// Then use this information to identify cli
+	// args for given target (calling function)
+	//--------------------------------------------
+	programCounter := make([]uintptr, 15)
+	entriesCount := runtime.Callers(2, programCounter)
+	frames := runtime.CallersFrames(programCounter[:entriesCount])
+	frame, _ := frames.Next()
+	// add ":" to the name of calling function, to form target prefix
+	callingFunction := strings.ToLower(frame.Function) + ":"
+	//--------------------------------------------
+	// Loop trough all os.Args and check it's prefixes
+	args = []string{}
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, MageStopProcArgsPrefix) {
+			// if we found "mage-stop:" prefix then don't
+			// process any more args, and return what has
+			// been already collected
+			return args
+		}
+		// first, look for args with prefix mage-target-args:
+		if strings.HasPrefix(arg, MageTargetArgsPrefix) {
+			arg = strings.TrimPrefix(arg, MageTargetArgsPrefix)
+			// then, look for args with prefix main.callingFunction
+			if strings.HasPrefix(arg, callingFunction) {
+				arg = strings.TrimPrefix(arg, callingFunction)
+				if !strings.HasPrefix(arg, "-") {
+					// if given arg is missing "-" prefix (so it's in format var=value)
+					// then we have to implicitly append "--" in front of it
+					// in order to satisfy flags package
+					arg = "--" + arg
+				}
+				// here we append raw flag without any prefixes added earlier
+				// this can be easily parsed then by flags by each individial target
+				args = append(args, arg)
+			}
+		}
+	}
+	return args
+}


### PR DESCRIPTION
Hello Guys,

I’ve been using Mage for more than a month now, for some serious work and I can say it works brilliantly.

In the past I was using a lot of Make and the only thing I'm missing from Make in Mage is the ability to pass arguments to targets. 

For example, in Makefile I can do something like this:

```makefile
ARG=
target:
     action $(ARG)
```

and then call it from CLI like:

```bash
make target ARG=foo
```

I know I can use environmental variables for it and it works, but in my opinion it's a bit counter-intuitive when you want to build a nice tool using Mage which will allow user to work in natural fashion by first typing a command name and then feeding it with some arguments/params.

Clearly I'm not the only one who is missing this feature (according to these posts):

https://github.com/magefile/mage/issues/24
https://github.com/magefile/mage/issues/24#issuecomment-424758830

Over the weekend I came up with my own solution to this problem. At first I was trying simply to obtain args using os.Args at target "scope" but it didn't work, as all of passed args were removed, and also immediately I was given errors about mismatched target names (because args passed to targer were interpreted as targets names obviously).

After some reverse engineering I found out that at Mage code-level all args are delivered by the os nicely, but they get removed during Mage initial processing.

So in my solution I modified the template.go file in order to prevent arguments removal and also to prevent error about "unknown targets" so that passed args are no longer interpreted as targets names.

Each processed argument gets marked with prefixes based on the name of target which was preceding it. Because targets args are coming after targets names, we can know which args belong to which target.
Also, my code is dealing correctly with target aliases; aliases are resolved to full original target name and stored as such in a prefix instead. Those names have to later match with caller function detection (more about this later).

The following flags format are supported:

```bash
// --                                          : stop processing any further arguments
// -f --f -flag --flag                         : boolean flags only
// -f=value --f=value -flag=value --flag=value : boolean, integer, string flags
// f=value flag=value                          : boolean, integer, string flags (read above below note)
```

Those formats are matched using below RegEx:
```bash
(^\w+\=\S*)|(^-{1,2}\w+\=\S*)|(^-{1,2}\w+$)
```
(it can be validated here: https://regex101.com/)

Given that we have three targets:
```bash
new
build
run
```

General format:
```bash
mage target1 [FLAGS] target2 [FLAGS] ...
```

examples:
```bash
mage target1 --boolean-flag --long-flag=abc -r=30 -v target2 --some-other-value="5a23d6eb3bdbcd6" -vv var=123
```

```bash
mage new
mage new --name=banana --input='/some/path/to/file.ext' --enabled -r
mage new --name=banana --input='/some/path/to/file.ext' --enabled -r build stage=dev -n=3 run
```

There is also support provided for ```--``` which is causing Mage to stop processing any further CLI arguments or running any further targets:
in the following example, only ```new``` and ```build``` target will be called, and ```build``` will only get ```stage``` argument, but not ```n``` argument for example.

(Note: please notice ```--``` after ```stage=dev```)
```bash
mage new --name=banana --input='/some/path/to/file.ext' --enabled -r build stage=dev -- -n=3 run
```

Some examples:
```bash
-f
-1
-flag
--f
--1
--flag
-a="/path/to/file" --nextFlag
-1="/path/to/file"
-flag="/path/to/file"
--a="/path/to/file"
--1="/path/to/file"
--flag="/path/to/file"
-f=
-1=
-f=3 --nextFlag
-1=abc
-flag=cheese
--f=
--f=300millions
--1=awesomeness
--flag="/path/to/file"
var=
var=some
other_var=something
```

These cases are ignored by this RegEx:
```bash
-
--
target
another_target
---b
---banana
```

Processing args at example "New" target

In the below snippet the crucial part of the way it works
is this function call:

```go
mg.GetArgsForTarget()
```

This function is checking callstack and finds out the name of the caller function,
then it's checking all CLI args available at os.Args and finds those which contains caller function
name in it (e.g.: ```main.new:``` ). Then it returns the list of all those found args as strings array
which can then be processed by flags package as follows:

```bash
mage new --name=banana --input='/some/path/to/banana.jpg' --enabled -r=30
```

```go
type NewOptions struct {
    Name    string
    Input   string
    Enabled bool
    R       int
}

func New() {
    var defaultOptions NewOptions
    options := defaultOptions
    //----------------------------
    // Here we call our args filtering
    // function, which will give us
    // only arguments applying to "New" target
    //----------------------------
    args := mg.GetArgsForTarget()
    //----------------------------
    // process args using flags package, and do whatever you want
    fs := flag.NewFlagSet("mytool new", flag.ExitOnError)
    fs.StringVar(&options.Name, "name", "models", "resource name")
    fs.StringVar(&options.Name, "n", "models", "resource name")
    fs.StringVar(&options.Input, "input", "", "resource path")
    fs.StringVar(&options.Input, "i", "", "resource path")
    fs.BoolVar(&options.Enabled, "enabled", false, "something is enabled")
    fs.BoolVar(&options.Enabled, "e", false, "something is enabled")
    fs.IntVar(&options.R, "r", 0, "radius")
    fs.Parse(args)
    //----------------------------
    // Deal with any parsed args
    // as object nicely here
    //----------------------------
    fmt.Println("Created New Project!")
    fmt.Println("Name: ", options.Name)
    fmt.Println("Input: ", options.Input)
```


ps.
I was testing this code a lot, and it's working for me.
Let me know what you think about this change and I'll write tests for it :)
