### PR TITLE
set working directory on Cmd if variable #CWD is set (#213)

### DIFF
--- a/sh/cmd.go
+++ b/sh/cmd.go
@@ -88,8 +88,10 @@ func OutputWith(env map[string]string, cmd string, args ...string) (string, erro
 // an error that, if returned from a target or mg.Deps call, will cause mage to
 // exit with the same code as the command failed with.  Env is a list of
 // environment variables to set when running the command, these override the
-// current environment variables set (which are also passed to the command). cmd
-// and args may include references to environment variables in $FOO format, in
+// current environment variables set (which are also passed to the command).
+// If the variable #CWD is set, the value will be used as working directory
+// when running the command.
+// cmd and args may include references to environment variables in $FOO format, in
 // which case these will be expanded before the command is run.
 //
 // Ran reports if the command ran (rather than was not found or not executable).
@@ -121,6 +123,11 @@ func run(env map[string]string, stdout, stderr io.Writer, cmd string, args ...st
 	c := exec.Command(cmd, args...)
 	c.Env = os.Environ()
 	for k, v := range env {
+		// if environment variable #CWD is set, use the value as working directory by setting Cmd.Dir
+		if k == "#CWD" {
+			c.Dir = v
+			continue
+		}
 		c.Env = append(c.Env, k+"="+v)
 	}
 	c.Stderr = stderr

--- a/sh/cmd_test.go
+++ b/sh/cmd_test.go
@@ -47,6 +47,21 @@ func TestEnv(t *testing.T) {
 	}
 }
 
+func TestCwd(t *testing.T) {
+	env := "SOME_REALLY_LONG_MAGEFILE_SPECIFIC_THING"
+	out := &bytes.Buffer{}
+	ran, err := Exec(map[string]string{"#CWD": "/tmp"}, out, nil, "pwd", env)
+	if err != nil {
+		t.Fatalf("unexpected error from runner: %#v", err)
+	}
+	if !ran {
+		t.Errorf("expected ran to be true but was false.")
+	}
+	if out.String() != "/tmp\n" {
+		t.Errorf("expected /tmp, got %q", out)
+	}
+}
+
 func TestNotRun(t *testing.T) {
 	ran, err := Exec(nil, nil, nil, "thiswontwork")
 	if err == nil {


### PR DESCRIPTION
This allows to specify a directory (the value of a variable `#CWD` in the env list) where the commands are executed. Useful when the Magefile is in a different directory than where you want to execute the cmd's.