### PR TITLE
New Flag: -nodeps: skip target dependencies when executing target

### DIFF
--- a/mg/deps.go
+++ b/mg/deps.go
@@ -92,6 +92,10 @@ func CtxDeps(ctx context.Context, fns ...interface{}) {
 
 // runDeps assumes you've already called checkFns.
 func runDeps(ctx context.Context, types []funcType, fns []interface{}) {
+	if os.Getenv(NoDepsEnv) == "1" {
+		return
+	}
+
 	mu := &sync.Mutex{}
 	var errs []string
 	var exit int

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -27,6 +27,10 @@ const GoCmdEnv = "MAGEFILE_GOCMD"
 // to ignore the default target specified in the magefile.
 const IgnoreDefaultEnv = "MAGEFILE_IGNOREDEFAULT"
 
+// NoDepsEnv is the environment variable that indicates the user requested
+// that dependencies of the target not be executed
+const NoDepsEnv = "MAGEFILE_NODEPS"
+
 // Verbose reports whether a magefile was run with the verbose flag.
 func Verbose() bool {
 	b, _ := strconv.ParseBool(os.Getenv(VerboseEnv))

--- a/site/content/dependencies/_index.en.md
+++ b/site/content/dependencies/_index.en.md
@@ -72,3 +72,13 @@ Build running
 Note that since f and g do not depend on each other, and they're running in
 their own goroutines, their order is non-deterministic, other than they are
 guaranteed to run after h has finished, and before Build continues.
+
+### Skipping Dependencies
+
+You can tell mage to execute a target but not its dependencies by passing
+the `-nodeps` flag when running mage. Using the example above, running
+`mage -nodeps build` will produce the following output:
+
+```bash
+Build running
+```


### PR DESCRIPTION
When you run mage with '-nodeps', mage will skip any Deps/SerialDeps
in the target being executed. This is useful when you want to run a
single target or need to run targets with dependencies locally but
without dependencies in CI for timing / visibility reasons.

Fixes #250 