### PR TITLE
add MAGEFILE_HASHFAST to avoid rerunning go build

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -110,6 +110,7 @@ type Invocation struct {
 	Args       []string      // args to pass to the compiled binary
 	GoCmd      string        // the go binary command to run
 	CacheDir   string        // the directory where we should store compiled binaries
+	HashFast   bool          // don't rely on GOCACHE, just hash the magefiles
 }
 
 // ParseAndRun parses the command line, and then compiles and runs the mage
@@ -282,7 +283,7 @@ Options:
 	if len(inv.Args) > 0 && cmd != None {
 		return inv, cmd, fmt.Errorf("unexpected arguments to command: %q", inv.Args)
 	}
-
+	inv.HashFast = mg.HashFast()
 	return inv, cmd, err
 }
 
@@ -321,12 +322,16 @@ func Invoke(inv Invocation) int {
 	debug.Println("output exe is ", exePath)
 
 	useCache := false
-	if s, err := internal.OutputDebug(inv.GoCmd, "env", "GOCACHE"); err == nil {
-		// if GOCACHE exists, always rebuild, so we catch transitive
-		// dependencies that have changed.
-		if s != "" {
-			debug.Println("build cache exists, will ignore any compiled binary")
-			useCache = true
+	if inv.HashFast {
+		debug.Println("user has set MAGEFILE_HASHFAST, so we'll ignore GOCACHE")
+	} else {
+		if s, err := internal.OutputDebug(inv.GoCmd, "env", "GOCACHE"); err == nil {
+			// if GOCACHE exists, always rebuild, so we catch transitive
+			// dependencies that have changed.
+			if s != "" {
+				debug.Println("go build cache exists, will ignore any compiled binary")
+				useCache = true
+			}
 		}
 	}
 

--- a/mage/testdata/transitiveDeps/magefile.go
+++ b/mage/testdata/transitiveDeps/magefile.go
@@ -2,7 +2,7 @@
 
 package main
 
-import "./dep"
+import "github.com/magefile/mage/mage/testdata/transitiveDeps/dep"
 
 func Run() {
 	dep.Speak()

--- a/mg/runtime.go
+++ b/mg/runtime.go
@@ -27,6 +27,13 @@ const GoCmdEnv = "MAGEFILE_GOCMD"
 // to ignore the default target specified in the magefile.
 const IgnoreDefaultEnv = "MAGEFILE_IGNOREDEFAULT"
 
+// HashFastEnv is the environment variable that indicates the user requested to
+// use a quick hash of magefiles to determine whether or not the magefile binary
+// needs to be rebuilt. This results in faster runtimes, but means that mage
+// will fail to rebuild if a dependency has changed. To force a rebuild, run
+// mage with the -f flag.
+const HashFastEnv = "MAGEFILE_HASHFAST"
+
 // Verbose reports whether a magefile was run with the verbose flag.
 func Verbose() bool {
 	b, _ := strconv.ParseBool(os.Getenv(VerboseEnv))
@@ -46,6 +53,13 @@ func GoCmd() string {
 		return cmd
 	}
 	return "go"
+}
+
+// HashFast reports whether the user has requested to use the fast hashing
+// mechanism rather than rely on go's rebuilding mechanism.
+func HashFast() bool {
+	b, _ := strconv.ParseBool(os.Getenv(HashFastEnv))
+	return b
 }
 
 // IgnoreDefault reports whether the user has requested to ignore the default target

--- a/site/content/environment/_index.en.md
+++ b/site/content/environment/_index.en.md
@@ -22,5 +22,13 @@ Sets the binary that mage will use to compile with (default is "go").
 
 ## MAGEFILE_IGNOREDEFAULT
 
-If set to 1 or true, will tell the compiled magefile to ignore the default
+If set to "1" or "true", tells the compiled magefile to ignore the default
 target and print the list of targets when you run `mage`.
+
+## MAGEFILE_HASHFAST
+
+If set to "1" or "true", tells mage to use a quick hash of magefiles to
+determine whether or not the magefile binary needs to be rebuilt. This results
+in faster run times (especially on Windows), but means that mage will fail to
+rebuild if a dependency has changed. To force a rebuild when you know or suspect
+a dependency has changed, run mage with the -f flag.


### PR DESCRIPTION
This is a feature that is mostly aimed at developers running on Windows. For some reason, the `go build` code that determines whether it needs to rebuild is slow on windows.  For people running mage, that means that even if no code has changed, it can take a full second or longer for mage to figure out it can just reuse the binary it already built.  

To solve that problem, this PR adds an environment variable you can set to tell mage to just use the hash of the magefiles themselves, and not run `go build`.  This is the way mage used to work before moving to rely on go build's cache.  

The one drawback of this method is that if a dependency of the magefile has changed (like your magefile imports a library that gets updated), mage won't detect the change and will just rerun the binary it has cached.  You can force the rebuild by using the already-existing -f flag.