### PR TITLE
enable detail/stack printing for "the Go 2 proposal for error values"

### DIFF
--- a/mage/template.go
+++ b/mage/template.go
@@ -174,7 +174,7 @@ Options:
 
 	handleError := func(logger *log.Logger, err interface{}) {
 		if err != nil {
-			logger.Printf("Error: %v\n", err)
+			logger.Printf("Error: %+v\n", err)
 			type code interface {
 				ExitStatus() int
 			}


### PR DESCRIPTION
This one character tweak allows the details/stack printing for the new error values defined by golang/x/xerrors as well as the new errors package in Go 1.13.

If an error is not defined as the new way, it will fall back to the traditional Error() message as usual.
