### PR TITLE
Add missing dependency to example Magefile

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -41,6 +41,10 @@ You may also install a binary release from our
 
 package main
 
+import (
+    "github.com/magefile/mage/sh"
+)
+
 // Runs dep ensure and then installs the binary.
 func Build() error {
     if err := sh.Run("dep", "ensure"); err != nil {


### PR DESCRIPTION
Add the missing dependency github.com/magefile/mage/sh to example Magefile.