### PR TITLE
Set GOARCH to amd64 for TestListMagefilesIgnoresRespectsGOOSArg

### DIFF
--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -206,7 +206,8 @@ func TestListMagefilesIgnoresRespectsGOOSArg(t *testing.T) {
 	} else {
 		goos = "windows"
 	}
-	files, err := Magefiles("testdata/goos_magefiles", goos, "", "go", buf, false)
+	// Set GOARCH as amd64 because windows is not on all non-x86 architectures.
+	files, err := Magefiles("testdata/goos_magefiles", goos, "amd64", "go", buf, false)
 	if err != nil {
 		t.Errorf("error from magefile list: %v: %s", err, buf)
 	}


### PR DESCRIPTION
The TestListMagefilesIgnoresRespectsGOOSArg test tries to list go
files with a different GOOS arg by setting GOOS to windows on Linux
systems and vice versa.  This test works fine on amd64, but breaks on
arm64 because a windows/arm64 pair is not available yet and as a
result, the `go list` command underlying the `Magefiles` function
fails.

Fix this problem by keeping GOARCH as amd64 so that the go list
command does not fail.