### PR TITLE
Set magefiles working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ mage_output_file.go
 # Goland
 .idea
 *.iml
+
+# Vim
+*.sw[op]
+Session.vim
+*~
+
+# GNU Screen
+.screenrc

--- a/mage/main.go
+++ b/mage/main.go
@@ -214,7 +214,7 @@ Options:
   -d <string> 
             directory to read magefiles from (default ".")
   -C <string>
-            working directory where magefiles will run (default ".")
+            working directory where magefiles will run (default -d value)
   -debug    turn on debug messages
   -h        show description of a target
   -f        force recreation of compiled magefile

--- a/mage/main.go
+++ b/mage/main.go
@@ -301,6 +301,9 @@ func Invoke(inv Invocation) int {
 	if inv.Dir == "" {
 		inv.Dir = "."
 	}
+	if inv.WorkDir == "" {
+		inv.WorkDir = inv.Dir
+	}
 	if inv.CacheDir == "" {
 		inv.CacheDir = mg.CacheDir()
 	}
@@ -620,7 +623,8 @@ func RunCompiled(inv Invocation, exePath string, errlog *log.Logger) int {
 	c.Stderr = inv.Stderr
 	c.Stdout = inv.Stdout
 	c.Stdin = inv.Stdin
-	if inv.Dir != inv.WorkDir {
+	c.Dir = inv.Dir
+	if inv.WorkDir != inv.Dir {
 		c.Dir = inv.WorkDir
 	}
 	// intentionally pass through unaltered os.Environ here.. your magefile has

--- a/mage/main.go
+++ b/mage/main.go
@@ -178,7 +178,7 @@ func Parse(stderr, stdout io.Writer, args []string) (inv Invocation, cmd Command
 	fs.DurationVar(&inv.Timeout, "t", 0, "timeout in duration parsable format (e.g. 5m30s)")
 	fs.BoolVar(&inv.Keep, "keep", false, "keep intermediate mage files around after running")
 	fs.StringVar(&inv.Dir, "d", ".", "directory to read magefiles from")
-	fs.StringVar(&inv.WorkDir, "C", inv.Dir, "working directory where magefiles will run")
+	fs.StringVar(&inv.WorkDir, "w", inv.Dir, "working directory where magefiles will run")
 	fs.StringVar(&inv.GoCmd, "gocmd", mg.GoCmd(), "use the given go binary to compile the output")
 	fs.StringVar(&inv.GOOS, "goos", "", "set GOOS for binary produced with -compile")
 	fs.StringVar(&inv.GOARCH, "goarch", "", "set GOARCH for binary produced with -compile")
@@ -213,7 +213,7 @@ Commands:
 Options:
   -d <string> 
             directory to read magefiles from (default ".")
-  -C <string>
+  -w <string>
             working directory where magefiles will run (default -d value)
   -debug    turn on debug messages
   -h        show description of a target

--- a/mage/main.go
+++ b/mage/main.go
@@ -205,27 +205,27 @@ Commands:
   -clean    clean out old generated binaries from CACHE_DIR
   -compile <string>
             output a static binary to the given path
+  -h        show this help
   -init     create a starting template if no mage files exist
   -l        list mage targets in this directory
-  -h        show this help
   -version  show version info for the mage binary
 
 Options:
   -d <string> 
             directory to read magefiles from (default ".")
-  -w <string>
-            working directory where magefiles will run (default -d value)
   -debug    turn on debug messages
-  -h        show description of a target
   -f        force recreation of compiled magefile
-  -keep     keep intermediate mage files around after running
+  -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
   -gocmd <string>
 		    use the given go binary to compile the output (default: "go")
   -goos     sets the GOOS for the binary created by -compile (default: current OS)
-  -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
+  -h        show description of a target
+  -keep     keep intermediate mage files around after running
   -t <string>
             timeout in duration parsable format (e.g. 5m30s)
   -v        show verbose output when running mage targets
+  -w <string>
+            working directory where magefiles will run (default -d value)
 `[1:])
 	}
 	err = fs.Parse(args)

--- a/mage/main.go
+++ b/mage/main.go
@@ -96,6 +96,7 @@ func Main() int {
 type Invocation struct {
 	Debug      bool          // turn on debug messages
 	Dir        string        // directory to read magefiles from
+	WorkDir    string        // directory where magefiles will run
 	Force      bool          // forces recreation of the compiled binary
 	Verbose    bool          // tells the magefile to print out log statements
 	List       bool          // tells the magefile to print out a list of targets
@@ -176,7 +177,8 @@ func Parse(stderr, stdout io.Writer, args []string) (inv Invocation, cmd Command
 	fs.BoolVar(&inv.Help, "h", false, "show this help")
 	fs.DurationVar(&inv.Timeout, "t", 0, "timeout in duration parsable format (e.g. 5m30s)")
 	fs.BoolVar(&inv.Keep, "keep", false, "keep intermediate mage files around after running")
-	fs.StringVar(&inv.Dir, "d", ".", "run magefiles in the given directory")
+	fs.StringVar(&inv.Dir, "d", ".", "directory to read magefiles from")
+	fs.StringVar(&inv.WorkDir, "C", inv.Dir, "working directory where magefiles will run")
 	fs.StringVar(&inv.GoCmd, "gocmd", mg.GoCmd(), "use the given go binary to compile the output")
 	fs.StringVar(&inv.GOOS, "goos", "", "set GOOS for binary produced with -compile")
 	fs.StringVar(&inv.GOARCH, "goarch", "", "set GOARCH for binary produced with -compile")
@@ -210,7 +212,9 @@ Commands:
 
 Options:
   -d <string> 
-            run magefiles in the given directory (default ".")
+            directory to read magefiles from (default ".")
+  -C <string>
+            working directory where magefiles will run (default ".")
   -debug    turn on debug messages
   -h        show description of a target
   -f        force recreation of compiled magefile
@@ -616,7 +620,9 @@ func RunCompiled(inv Invocation, exePath string, errlog *log.Logger) int {
 	c.Stderr = inv.Stderr
 	c.Stdout = inv.Stdout
 	c.Stdin = inv.Stdin
-	c.Dir = inv.Dir
+	if inv.Dir != inv.WorkDir {
+		c.Dir = inv.WorkDir
+	}
 	// intentionally pass through unaltered os.Environ here.. your magefile has
 	// to deal with it.
 	c.Env = os.Environ()

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -783,6 +783,30 @@ func TestSetDir(t *testing.T) {
 	}
 }
 
+func TestSetWorkingDir(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Invoke(Invocation{
+		Dir:     "testdata/setworkdir",
+		WorkDir: "testdata/setworkdir/data",
+		Stdout:  stdout,
+		Stderr:  stderr,
+		Args:    []string{"TestWorkingDir"},
+	})
+
+	if code != 0 {
+		t.Errorf(
+			"expected code 0, but got %d. Stdout:\n%s\nStderr:\n%s",
+			code, stdout, stderr,
+		)
+	}
+
+	expected := "file1.txt, file2.txt\n"
+	if out := stdout.String(); out != expected {
+		t.Fatalf("expected list of files to be %q, but was %q", expected, out)
+	}
+}
+
 // Test the timeout option
 func TestTimeout(t *testing.T) {
 	stderr := &bytes.Buffer{}

--- a/mage/testdata/setworkdir/data/file1.txt
+++ b/mage/testdata/setworkdir/data/file1.txt
@@ -1,0 +1,1 @@
+lorem ipsum 1

--- a/mage/testdata/setworkdir/data/file2.txt
+++ b/mage/testdata/setworkdir/data/file2.txt
@@ -1,0 +1,1 @@
+lorem ipsum 2

--- a/mage/testdata/setworkdir/magefile.go
+++ b/mage/testdata/setworkdir/magefile.go
@@ -1,0 +1,23 @@
+//+build mage
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+func TestWorkingDir() error {
+	files, err := ioutil.ReadDir(".")
+	if err != nil {
+		return err
+	}
+	var out []string
+	for _, f := range files {
+		out = append(out, f.Name())
+	}
+
+	fmt.Println(strings.Join(out, ", "))
+	return nil
+}

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -81,27 +81,27 @@ Commands:
   -clean    clean out old generated binaries from CACHE_DIR
   -compile <string>
             output a static binary to the given path
+  -h        show this help
   -init     create a starting template if no mage files exist
   -l        list mage targets in this directory
-  -h        show this help
   -version  show version info for the mage binary
 
 Options:
   -d <string> 
             directory to read magefiles from (default ".")
-  -w <string>
-            working directory where magefiles will run (default -d value)
   -debug    turn on debug messages
-  -h        show description of a target
   -f        force recreation of compiled magefile
-  -keep     keep intermediate mage files around after running
+  -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
   -gocmd <string>
 		    use the given go binary to compile the output (default: "go")
   -goos     sets the GOOS for the binary created by -compile (default: current OS)
-  -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
+  -h        show description of a target
+  -keep     keep intermediate mage files around after running
   -t <string>
             timeout in duration parsable format (e.g. 5m30s)
   -v        show verbose output when running mage targets
+  -w <string>
+            working directory where magefiles will run (default -d value)
   ```
 
 ## Why?

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -88,7 +88,9 @@ Commands:
 
 Options:
   -d <string> 
-            run magefiles in the given directory (default ".")
+            directory to read magefiles from (default ".")
+  -C <string>
+            working directory where magefiles will run (default -d value)
   -debug    turn on debug messages
   -h        show description of a target
   -f        force recreation of compiled magefile

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -89,7 +89,7 @@ Commands:
 Options:
   -d <string> 
             directory to read magefiles from (default ".")
-  -C <string>
+  -w <string>
             working directory where magefiles will run (default -d value)
   -debug    turn on debug messages
   -h        show description of a target


### PR DESCRIPTION
This adds a `-w` flag for changing the magefiles working directory. Currently reading magefiles from other directory with `-d` flag set it as working directory for the magefiles.

This doesn't break any existing code since the `-w` flag default value is the same as `-d`, just people using explicitly a `-w` flag will get this behavior.

Fixes: #243 