### PR TITLE
Fix #276: filter mageimport files

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1,9 +1,17 @@
 package parse
 
 import (
+	"log"
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/magefile/mage/internal"
 )
+
+func init() {
+	internal.SetDebug(log.New(os.Stdout, "", 0))
+}
 
 func TestParse(t *testing.T) {
 	info, err := PrimaryPackage("go", "./testdata", []string{"func.go", "command.go", "alias.go", "repeating_synopsis.go", "subcommands.go"})
@@ -92,5 +100,15 @@ func TestParse(t *testing.T) {
 		if !found {
 			t.Fatalf("expected:\n%#v\n\nto be in:\n%#v", fn, info.Funcs)
 		}
+	}
+}
+
+func TestGetImportSelf(t *testing.T) {
+	imp, err := getImport("go", "github.com/magefile/mage/parse/testdata/importself", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imp.Info.AstPkg.Name != "importself" {
+		t.Fatalf("expected package importself, got %v", imp.Info.AstPkg.Name)
 	}
 }

--- a/parse/testdata/importself/magefile.go
+++ b/parse/testdata/importself/magefile.go
@@ -1,0 +1,14 @@
+//+build mage
+
+package main
+
+import (
+	"fmt"
+
+	// mage:import
+	_ "github.com/magefile/mage/parse/testdata/importself"
+)
+
+func Build(){
+	fmt.Println("built")
+}

--- a/parse/testdata/importself/targets.go
+++ b/parse/testdata/importself/targets.go
@@ -1,0 +1,7 @@
+package importself
+
+import "fmt"
+
+func Stuff() {
+	fmt.Println("stuff")
+}


### PR DESCRIPTION
When calling mage import, we weren't prefiltering the list of go files, so we'd get files with build tags and test files and such. What we want is just the normal go files for building the library.
Using go list returns us that, so use that.

This fixes https://github.com/magefile/mage/issues/276