### PR TITLE
Traverse upwards for magefiles

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -298,16 +298,25 @@ func Invoke(inv Invocation) int {
 	if inv.GoCmd == "" {
 		inv.GoCmd = "go"
 	}
+
+	inv.Dir = filepath.Clean(inv.Dir)
 	if inv.Dir == "" {
 		inv.Dir = "."
 	}
+	resolved, err := filepath.Abs(inv.Dir)
+	if err != nil {
+		errlog.Println("Cannot resolve absolute path from dir:", err)
+	} else {
+		inv.Dir = resolved
+	}
+
 	if inv.WorkDir == "" {
 		inv.WorkDir = inv.Dir
 	}
 	if inv.CacheDir == "" {
 		inv.CacheDir = mg.CacheDir()
 	}
-
+FINDFILES:
 	files, err := Magefiles(inv.Dir, inv.GOOS, inv.GOARCH, inv.GoCmd, inv.Stderr, inv.Debug)
 	if err != nil {
 		errlog.Println("Error determining list of magefiles:", err)
@@ -315,6 +324,15 @@ func Invoke(inv Invocation) int {
 	}
 
 	if len(files) == 0 {
+		if strings.HasSuffix(inv.Dir, "/") {
+			debug.Println("Reached root searching for magefiles")
+		} else {
+			inv.Dir = filepath.Dir(inv.Dir)
+			debug.Println("No .go files marked with the mage build tag in this directory")
+			debug.Println("Moving to parent to find magefiles")
+			goto FINDFILES
+		}
+
 		errlog.Println("No .go files marked with the mage build tag in this directory.")
 		return 1
 	}

--- a/site/content/howitworks/_index.en.md
+++ b/site/content/howitworks/_index.en.md
@@ -12,6 +12,9 @@ unchanged, the same compiled binary will be reused next time, to avoid the
 generation overhead.  As of Mage 1.3.0, the version of Go used to compile the
 binary is also used in the hash.
 
+When no magefiles are found in the current directory, Mage traverses upwards
+through the path attempting to find any magefiles.
+
 ## Binary Cache
 
 Compiled magefile binaries are stored in $HOME/.magefile.  This location can be


### PR DESCRIPTION
Currently, if you attempt to run `mage` from somewhere other than your project root you get an error:

```
No .go files marked with the mage build tag in this directory.
```

Coming from rake, I'm used to being able to run my tasks from any level deep within my project and be confident everything will run.

This change allows the resolution of the magefiles to traverse upwards until it reaches the root `/`. With this update, you can run `mage` from any level deep of your project and it will still find the magefiles and work as expected.

Also, despite invoking at some (possibly deep) nested path, the actual binary's working directory is the directory where the magefiles are located.