### PR TITLE
Improve error message for failed imports

### DIFF
--- a/internal/run.go
+++ b/internal/run.go
@@ -51,7 +51,7 @@ func OutputDebug(cmd string, args ...string) (string, error) {
 	c.Stdout = buf
 	if err := c.Run(); err != nil {
 		debug.Print("error running '", cmd, strings.Join(args, " "), "': ", err, ": ", errbuf)
-		return "", err
+		return "", fmt.Errorf("error running \"%s %s\": %w\n%s", cmd, strings.Join(args, " "), err, errbuf)
 	}
 	return strings.TrimSpace(buf.String()), nil
 }

--- a/internal/run.go
+++ b/internal/run.go
@@ -50,8 +50,9 @@ func OutputDebug(cmd string, args ...string) (string, error) {
 	c.Stderr = errbuf
 	c.Stdout = buf
 	if err := c.Run(); err != nil {
-		debug.Print("error running '", cmd, strings.Join(args, " "), "': ", err, ": ", errbuf)
-		return "", fmt.Errorf("error running \"%s %s\": %w\n%s", cmd, strings.Join(args, " "), err, errbuf)
+		errMsg := strings.TrimSpace(errbuf.String())
+		debug.Print("error running '", cmd, strings.Join(args, " "), "': ", err, ": ", errMsg)
+		return "", fmt.Errorf("error running \"%s %s\": %s\n%s", cmd, strings.Join(args, " "), err, errMsg)
 	}
 	return strings.TrimSpace(buf.String()), nil
 }

--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -187,3 +187,31 @@ func TestMageImportsOneLine(t *testing.T) {
 		t.Fatalf("expected: %q got: %q", expected, actual)
 	}
 }
+
+func TestMageImportsTaggedPackage(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport/tagged",
+		Stdout: stdout,
+		Stderr: stderr,
+		List:   true,
+	}
+
+	code := Invoke(inv)
+	if code != 1 {
+		t.Fatalf("expected to exit with code 1, but got %v, stdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+
+	actual := stderr.String()
+	expected := `
+Error parsing magefiles: error running "go list -f {{.Dir}}||{{.Name}} github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg": exit status 1
+can't load package: package github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg: build constraints exclude all Go files in /home/arve/Projects/mage/mage/testdata/mageimport/tagged/pkg
+
+`[1:]
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}

--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -204,9 +204,9 @@ func TestMageImportsTaggedPackage(t *testing.T) {
 	}
 
 	actual := stderr.String()
+	// Match a shorter version of the error message, since the output from go list differs between versions
 	expected := `
-Error parsing magefiles: error running "go list -f {{.Dir}}||{{.Name}} github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg": exit status 1
-can't load package: package github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg:`[1:]
+Error parsing magefiles: error running "go list -f {{.Dir}}||{{.Name}} github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg": exit status 1`[1:]
 	actualShortened := actual[:len(expected)]
 	if actualShortened != expected {
 		t.Logf("expected: %q", expected)

--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -206,7 +206,7 @@ func TestMageImportsTaggedPackage(t *testing.T) {
 	actual := stderr.String()
 	expected := `
 Error parsing magefiles: error running "go list -f {{.Dir}}||{{.Name}} github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg": exit status 1
-can't load package: package github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg: build constraints exclude all Go files`[1:]
+can't load package: package github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg:`[1:]
 	actualShortened := actual[:len(expected)]
 	if actualShortened != expected {
 		t.Logf("expected: %q", expected)

--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -206,12 +206,11 @@ func TestMageImportsTaggedPackage(t *testing.T) {
 	actual := stderr.String()
 	expected := `
 Error parsing magefiles: error running "go list -f {{.Dir}}||{{.Name}} github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg": exit status 1
-can't load package: package github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg: build constraints exclude all Go files in /home/arve/Projects/mage/mage/testdata/mageimport/tagged/pkg
-
-`[1:]
-	if actual != expected {
+can't load package: package github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg: build constraints exclude all Go files`[1:]
+	actualShortened := actual[:len(expected)]
+	if actualShortened != expected {
 		t.Logf("expected: %q", expected)
-		t.Logf("  actual: %q", actual)
-		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+		t.Logf("  actual: %q", actualShortened)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actualShortened)
 	}
 }

--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -210,7 +210,7 @@ can't load package: package github.com/magefile/mage/mage/testdata/mageimport/ta
 	actualShortened := actual[:len(expected)]
 	if actualShortened != expected {
 		t.Logf("expected: %q", expected)
-		t.Logf("  actual: %q", actualShortened)
-		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actualShortened)
+		t.Logf("actual: %q", actualShortened)
+		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actualShortened)
 	}
 }

--- a/mage/main.go
+++ b/mage/main.go
@@ -506,7 +506,7 @@ func Compile(goos, goarch, magePath, goCmd, compileTo string, gofiles []string, 
 	for i := range gofiles {
 		gofiles[i] = filepath.Base(gofiles[i])
 	}
-	args := append([]string{"build", "-o", compileTo, "-tags", "mage"}, gofiles...)
+	args := append([]string{"build", "-o", compileTo}, gofiles...)
 	debug.Printf("running %s %s", goCmd, strings.Join(args, " "))
 	c := exec.Command(goCmd, args...)
 	c.Env = environ

--- a/mage/main.go
+++ b/mage/main.go
@@ -506,8 +506,9 @@ func Compile(goos, goarch, magePath, goCmd, compileTo string, gofiles []string, 
 	for i := range gofiles {
 		gofiles[i] = filepath.Base(gofiles[i])
 	}
-	debug.Printf("running %s build -o %s %s", goCmd, compileTo, strings.Join(gofiles, " "))
-	c := exec.Command(goCmd, append([]string{"build", "-o", compileTo}, gofiles...)...)
+	args := append([]string{"build", "-o", compileTo, "-tags", "mage"}, gofiles...)
+	debug.Printf("running %s %s", goCmd, strings.Join(args, " "))
+	c := exec.Command(goCmd, args...)
 	c.Env = environ
 	c.Stderr = stderr
 	c.Stdout = stdout

--- a/mage/testdata/mageimport/tagged/magefile.go
+++ b/mage/testdata/mageimport/tagged/magefile.go
@@ -1,0 +1,8 @@
+//+build mage
+
+package main
+
+import (
+	// mage:import
+	_ "github.com/magefile/mage/mage/testdata/mageimport/tagged/pkg"
+)

--- a/mage/testdata/mageimport/tagged/pkg/mage.go
+++ b/mage/testdata/mageimport/tagged/pkg/mage.go
@@ -1,0 +1,7 @@
+//+build mage
+
+package pkg
+
+// Build builds stuff.
+func Build() {
+}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -232,7 +232,7 @@ func getNamedImports(gocmd string, pkgs map[string]string) ([]*Import, error) {
 
 // getImport returns the metadata about a package that has been mage:import'ed.
 func getImport(gocmd, importpath, alias string) (*Import, error) {
-	out, err := internal.OutputDebug(gocmd, "list", "-f", "{{.Dir}}||{{.Name}}", importpath)
+	out, err := internal.OutputDebug(gocmd, "list", "-tags", "mage", "-f", "{{.Dir}}||{{.Name}}", importpath)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func getImport(gocmd, importpath, alias string) (*Import, error) {
 	// we use go list to get the list of files, since go/parser doesn't differentiate between
 	// go files with build tags etc, and go list does. This prevents weird problems if you
 	// have more than one package in a folder because of build tags.
-	out, err = internal.OutputDebug(gocmd, "list", "-f", `{{join .GoFiles "||"}}`, importpath)
+	out, err = internal.OutputDebug(gocmd, "list", "-tags", "mage", "-f", `{{join .GoFiles "||"}}`, importpath)
 	if err != nil {
 		return nil, err
 	}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -232,7 +232,7 @@ func getNamedImports(gocmd string, pkgs map[string]string) ([]*Import, error) {
 
 // getImport returns the metadata about a package that has been mage:import'ed.
 func getImport(gocmd, importpath, alias string) (*Import, error) {
-	out, err := internal.OutputDebug(gocmd, "list", "-tags", "mage", "-f", "{{.Dir}}||{{.Name}}", importpath)
+	out, err := internal.OutputDebug(gocmd, "list", "-f", "{{.Dir}}||{{.Name}}", importpath)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func getImport(gocmd, importpath, alias string) (*Import, error) {
 	// we use go list to get the list of files, since go/parser doesn't differentiate between
 	// go files with build tags etc, and go list does. This prevents weird problems if you
 	// have more than one package in a folder because of build tags.
-	out, err = internal.OutputDebug(gocmd, "list", "-tags", "mage", "-f", `{{join .GoFiles "||"}}`, importpath)
+	out, err = internal.OutputDebug(gocmd, "list", "-f", `{{join .GoFiles "||"}}`, importpath)
 	if err != nil {
 		return nil, err
 	}

--- a/site/content/importing/_index.en.md
+++ b/site/content/importing/_index.en.md
@@ -14,14 +14,13 @@ package.  i.e. it cannot be `package main`.  This is in contrast to a normal
 mage package that must be `package main`.  The reason is that the go tool won't
 let you import a main package.
 
-In addition, all files will be imported, not just those tagged with the
-`//+build mage` build tag.  Again, this is a restriction of the go tool.  Mage
-can build only the `.go` files in the current directory that have the `mage`
-build tag, but when importing code from other directories, it's simply not
-possible.  This means that any exported function (in any file) that matches
-Mage's allowed formats will be picked up as a target. 
+In addition, all package files will be imported, so long as they don't have a 
+build tag.  If you try to import a package consisting only of files with build 
+tags (e.g. `//+build mage`), it will cause an error since mage doesn't set any 
+build tags when importing packages.  Any exported function, in imported 
+packages, that matches Mage's allowed formats will be picked up as a target.
 
-Aliases and defaults in the imported package will be ignored. 
+Aliases and defaults in imported packages will be ignored. 
 
 Other than these differences, you can write targets in those packages just
 like a normal magefile.


### PR DESCRIPTION
This PR improves the error message when importing packages fails, for example because an imported package has a build tag (e.g. `mage`). A test is also included.

Plus, I edited the documentation to clarify how Mage doesn't support importing package files with build tags.