### PR TITLE
Ensure MAGEFILE_VERBOSE set in compiled magefile

### DIFF
--- a/mage/template.go
+++ b/mage/template.go
@@ -186,6 +186,13 @@ Options:
 	}
 	_ = handleError
 
+	// Set MAGEFILE_VERBOSE so mg.Verbose() reflects the flag value.
+	if args.Verbose {
+		os.Setenv("MAGEFILE_VERBOSE", "1")
+	} else {
+		os.Setenv("MAGEFILE_VERBOSE", "0")
+	}
+
 	log.SetFlags(0)
 	if !args.Verbose {
 		log.SetOutput(ioutil.Discard)

--- a/mage/testdata/compiled/custom.go
+++ b/mage/testdata/compiled/custom.go
@@ -14,7 +14,9 @@ var Default = Deploy
 
 // This is very verbose.
 func TestVerbose() {
-	log.Println("hi!")
+	if mg.Verbose() {
+		log.Println("hi!")
+	}
 }
 
 // This is the synopsis for Deploy. This part shouldn't show up.

--- a/mage/testdata/compiled/custom.go
+++ b/mage/testdata/compiled/custom.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -14,9 +15,12 @@ var Default = Deploy
 
 // This is very verbose.
 func TestVerbose() {
-	if mg.Verbose() {
-		log.Println("hi!")
-	}
+	log.Println("hi!")
+}
+
+// PrintVerboseFlag prints the value of mg.Verbose() to stdout.
+func PrintVerboseFlag() {
+	fmt.Printf("mg.Verbose()==%v", mg.Verbose())
 }
 
 // This is the synopsis for Deploy. This part shouldn't show up.


### PR DESCRIPTION
When using `mage -compile=foo`, ensure that passing
`-v` to the produced binary sets MAGEFILE_VERBOSE.
This is necessary for `mg.Verbose()` to return the
correct value.

Fixes https://github.com/magefile/mage/issues/248