### PR TITLE
update release pipeline slightly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,6 @@ build:
     - dragonfly
   goarch:
     - amd64
-    - 386
     - arm
     - arm64
   ignore:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ branches:
 # library, I'm not going to worry about older versions for now.
 go:
   - tip
+  - 1.15.x
+  - 1.14.x
   - 1.13.x
   - 1.12.x
   - 1.11.x
   - 1.10.x
   - 1.9.x
-  - 1.8.x
-  - 1.7.x
 
 # don't call go get ./... because this hides when deps are
 # not packaged into the vendor directory.

--- a/magefile.go
+++ b/magefile.go
@@ -67,10 +67,8 @@ func Install() error {
 
 var releaseTag = regexp.MustCompile(`^v1\.[0-9]+\.[0-9]+$`)
 
-// Generates a new release.  Expects the TAG environment variable to be set,
-// which will create a new tag with that name.
-func Release() (err error) {
-	tag := os.Getenv("TAG")
+// Generates a new release. Expects a version tag in v1.x.x format.
+func Release(tag string) (err error) {
 	if !releaseTag.MatchString(tag) {
 		return errors.New("TAG environment variable must be in semver v1.x.x format, but was " + tag)
 	}


### PR DESCRIPTION
use new arg support for our own `mage release` target, plus remove 386 from the build targets, since modern versions of go stopped supporting stuff like darwin/386. 