### PR TITLE
Add command line flag support

### DIFF
--- a/mg/fn.go
+++ b/mg/fn.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+type StringFlag = string
+type BoolFlag = bool
+type IntFlag = int
+type DurationFlag = time.Duration
+type StringSliceFlag = []string
+
 // Fn represents a function that can be run with mg.Deps. Package, Name, and ID must combine to
 // uniquely identify a function, while ensuring the "same" function has identical values. These are
 // used as a map key to find and run (or not run) the function.

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -56,6 +56,16 @@ type Arg struct {
 	Name, Type string
 }
 
+// IsFlag detects if the argument is intended for use as a flag
+func (a Arg) IsFlag() bool {
+	return strings.HasPrefix(a.Type, "mg") && strings.HasSuffix(a.Type, "Flag")
+}
+
+// FlagType returns the underlying type for the flag (string, bool, etc)
+func (a Arg) FlagType() string {
+	return strings.TrimSuffix(strings.TrimPrefix(a.Type, "mg."), "Flag")
+}
+
 // ID returns user-readable information about where this function is defined.
 func (f Function) ID() string {
 	path := "<current>"
@@ -80,6 +90,28 @@ func (f Function) TargetName() string {
 		}
 	}
 	return strings.Join(names, ":")
+}
+
+// Flags extracts the Args intended to be defined by flags
+func (f Function) Flags() []Arg {
+	out := []Arg{}
+	for _, arg := range f.Args {
+		if arg.IsFlag() {
+			out = append(out, arg)
+		}
+	}
+	return out
+}
+
+// Positional extracts the Args that are positional in nature
+func (f Function) Positional() []Arg {
+	out := []Arg{}
+	for _, arg := range f.Args {
+		if !arg.IsFlag() {
+			out = append(out, arg)
+		}
+	}
+	return out
 }
 
 // ExecCode returns code for the template switch to run the target.
@@ -125,6 +157,39 @@ func (f Function) ExecCode() string {
 					os.Exit(2)
 				}
 				x++`, x)
+		case "mg.StringFlag":
+			parseargs += fmt.Sprintf(`
+		  arg%d := args.Flags["%s"][len(args.Flags["%s"])-1]
+		  `, x, arg.Name, arg.Name)
+		case "mg.BoolFlag":
+			parseargs += fmt.Sprintf(`
+				arg%d, err := strconv.ParseBool(args.Flags["%s"][len(args.Flags["%s"])-1])
+				if err != nil {
+					logger.Printf("can't convert argument %%q to bool\n", args.Flags["%s"])
+					os.Exit(2)
+				}
+				`, x, arg.Name, arg.Name, arg.Name)
+		case "mg.StringSliceFlag":
+			parseargs += fmt.Sprintf(`
+		  arg%d := args.Flags["%s"]
+		  `, x, arg.Name)
+		case "mg.IntFlag":
+			parseargs += fmt.Sprintf(`
+				arg%d, err := strconv.Atoi(args.Flags["%s"][len(args.Flags["%s"])-1])
+				if err != nil {
+					logger.Printf("can't convert argument %%q to int\n", args.Flags["%s"])
+					os.Exit(2)
+				}
+				`, x, arg.Name, arg.Name, arg.Name)
+		case "mg.DurationFlag":
+			parseargs += fmt.Sprintf(`
+				arg%d, err := time.ParseDuration(args.Flags["%s"])
+				if err != nil {
+					logger.Printf("can't convert argument %%q to time.Duration\n", args.Flags["%s"])
+					os.Exit(2)
+				}
+				`, x, arg.Name, arg.Name)
+
 		}
 	}
 
@@ -790,8 +855,12 @@ func toOneLine(s string) string {
 }
 
 var argTypes = map[string]string{
-	"string":           "string",
-	"int":              "int",
-	"&{time Duration}": "time.Duration",
-	"bool":             "bool",
+	"string":                "string",
+	"int":                   "int",
+	"&{time Duration}":      "time.Duration",
+	"bool":                  "bool",
+	"&{mg StringFlag}":      "mg.StringFlag",
+	"&{mg BoolFlag}":        "mg.BoolFlag",
+	"&{mg DurationFlag}":    "mg.DurationFlag",
+	"&{mg StringSliceFlag}": "mg.StringSliceFlag",
 }

--- a/site/content/targets/_index.en.md
+++ b/site/content/targets/_index.en.md
@@ -13,6 +13,7 @@ func Build()
 func Install(ctx context.Context) error
 func Run(what string) error
 func Exec(ctx context.Context, name string, count int, debug bool, timeout time.Duration) error
+func Greet(name string, loud mg.BoolFlag, count mg.IntFlag, debug mg.BoolFlag, every mg.DurationFlag)
 ```
 
 A target is effectively a subcommand of mage while running mage in
@@ -33,6 +34,56 @@ All arguments are mandatory and must be specified in the order they appear in th
 You can intersperse multiple targets with arguments as you'd expect:
 
 `mage run foo.exe exec somename 5 true 100ms`
+
+## Flags
+
+Flags are taken from the CLI arguments after the target name. They are
+converted into usable function parameters the same as other arguments. The name
+of the flag is the name of the parameter.
+
+Thus you could call Greet above by running:
+
+```
+mage greet Adam --loud
+mage greet Adam --count=3 --loud
+mage greet --every 5m --count=5 adam
+```
+
+All flags are optional and may be specified in any order. They can be combined
+with standard arguments and multiple targets as you'd expect.
+
+Available flag types are:
+
+```
+mg.StringFlag
+mg.IntFlag
+mg.BoolFlag
+mg.DurationFlag
+mg.StringSliceFlag
+```
+
+Each one, expect `mg.StringSliceFlag`, only allows a single usage, with the
+value of the last usage being the one that is used.
+
+The `mg.StringSliceFlag` allows the flag to be used multiple times.
+
+## Help/Usage Text
+
+If a help flag (-h, --help) is added after the target, usage information will
+be displayed.
+
+```plain
+$ mage say --help
+Usage:
+  mage say [options]  <animal>
+
+Options:
+  -h, --help    show this help
+  --loud        provide the loud argument (Bool)
+  --msgs        provide the msgs argument (StringSlice)
+
+```
+
 
 ## Errors
 


### PR DESCRIPTION
This builds on the work that was recently merged, adding argument support. I've extended it a bit, adding support for optional flags in addition to positional arguments.

Given the following function in a magefile:
```go
func Say(animal string, loud mg.BoolFlag, msgs mg.StringSliceFlag) {
        fmt.Println("what does the", animal, "say?")
	if loud {
		fmt.Println("GET LOUD")
	}

	for _, m := range msgs {
		if loud {
			m = strings.ToUpper(m)
		}
		fmt.Println(m)
	}
}
```

It can now be executed as any of the following:

```
mage say fox --loud --msgs="bark bark" --msgs="woof woof" --msgs="yip yip"
mage say fox --msgs="bark bark" --msgs="woof woof" --msgs="yip yip"
mage say --msgs="bark bark" --msgs="woof woof" --msgs="yip yip" fox
mage say fox --msgs="bark bark"
```