### PR TITLE
fix test for go 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 # library, I'm not going to worry about older versions for now.
 go:
   - tip
+  - 1.16.x
   - 1.15.x
   - 1.14.x
   - 1.13.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 # library, I'm not going to worry about older versions for now.
 go:
   - tip
-  - 1.16.x
+  - 1.16beta1
   - 1.15.x
   - 1.14.x
   - 1.13.x

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1436,6 +1436,18 @@ func Test() {
 	}
 	stderr.Reset()
 	stdout.Reset()
+
+	// we need to run go mod tidy, since go build will no longer auto-add dependencies.
+	cmd = exec.Command("go", "mod", "tidy")
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Error running go mod tidy: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
+	}
+	stderr.Reset()
+	stdout.Reset()
 	code := Invoke(Invocation{
 		Dir:    dir,
 		Stderr: stderr,


### PR DESCRIPTION
This fixes #329 - in 1.16, go build no longer automatically adds dependencies to the go.mod, so you have to manually run go mod tidy.