### PR TITLE
make -h work with imported targets

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -38,6 +38,104 @@ Targets:
 	}
 }
 
+func TestMageImportsHelp(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Help:   true,
+		Args:   []string{"buildSubdir"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := `
+BuildSubdir Builds stuff.
+
+Usage:
+
+	mage buildsubdir
+
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}
+
+func TestMageImportsHelpNamed(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Help:   true,
+		Args:   []string{"zz:buildSubdir2"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := `
+BuildSubdir2 Builds stuff.
+
+Usage:
+
+	mage zz:buildsubdir2
+
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}
+
+func TestMageImportsHelpNamedNS(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport",
+		Stdout: stdout,
+		Stderr: stderr,
+		Help:   true,
+		Args:   []string{"zz:ns:deploy2"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := `
+Deploy2 deploys stuff.
+
+Usage:
+
+	mage zz:ns:deploy2
+
+Aliases: nsd2
+
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}
+
 func TestMageImportsRoot(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/mage/template.go
+++ b/mage/template.go
@@ -339,7 +339,8 @@ Options:
 			os.Exit(2)
 		}
 		switch strings.ToLower(args.Args[0]) {
-			{{range .Funcs}}case "{{lower .TargetName}}":
+			{{range .Funcs -}}
+			case "{{lower .TargetName}}":
 				{{if ne .Comment "" -}}
 				fmt.Println({{printf "%q" .Comment}})
 				fmt.Println()
@@ -355,7 +356,27 @@ Options:
 					fmt.Printf("Aliases: %s\n\n", strings.Join(aliases, ", "))
 				}
 				return
-			{{end}}
+			{{end -}}
+			{{range .Imports -}}
+				{{range .Info.Funcs -}}
+			case "{{lower .TargetName}}":
+				{{if ne .Comment "" -}}
+				fmt.Println({{printf "%q" .Comment}})
+				fmt.Println()
+				{{end}}
+				fmt.Print("Usage:\n\n\t{{$.BinaryName}} {{lower .TargetName}}{{range .Args}} <{{.Name}}>{{end}}\n\n")
+				var aliases []string
+				{{- $name := .Name -}}
+				{{- $recv := .Receiver -}}
+				{{range $alias, $func := $.Aliases}}
+				{{if and (eq $name $func.Name) (eq $recv $func.Receiver)}}aliases = append(aliases, "{{$alias}}"){{end -}}
+				{{- end}}
+				if len(aliases) > 0 {
+					fmt.Printf("Aliases: %s\n\n", strings.Join(aliases, ", "))
+				}
+				return
+				{{end -}}
+			{{end -}}
 			default:
 				logger.Printf("Unknown target: %q\n", args.Args[0])
 				os.Exit(2)


### PR DESCRIPTION
fixes #249
Forgot to allow help to be called on imported targets. Kinda useful, eh?