### PR TITLE
Support for GOARM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/magefile/mage
 
 go 1.12
+
+require golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea h1:+WiDlPBBaO+h9vPNZi8uJ3k4BkKQB7Iow3aqwHVA5hI=
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/site/content/compiling/_index.en.md
+++ b/site/content/compiling/_index.en.md
@@ -3,9 +3,9 @@ title = "Compiling"
 weight = 37
 +++
 
-## Mage ignores GOOS and GOARCH for its build
+## Mage ignores GOOS, GOARCH and GOARM for its build
 
-When building the binary for your magefile, mage will ignore the GOOS and GOARCH environment variables and use your current GOOS and GOARCH to ensure the binary that is built can run on your local system.  This way you can set GOOS and GOARCH when you run mage, to have it take effect on the outputs of your magefile, without it also rendering your magefile unrunnable on your local machine.
+When building the binary for your magefile, mage will ignore the GOOS, GOARCH and GOARM environment variables and use your current GOOS, GOARCH and GOARM to ensure the binary that is built can run on your local system. This way you can set GOOS, GOARCH and GOARM when you run mage, to have it take effect on the outputs of your magefile, without it also rendering your magefile unrunnable on your local machine.
 
 ## Compiling a static binary
 
@@ -34,8 +34,8 @@ Options:
   -v    show verbose output when running targets
 ```
 
-## Compiling for a different OS -goos and -goarch
+## Compiling for a different OS -goos, -goarch and -goarm
 
-If you intend to run the binary on another machine with a different OS platform, you may use the `-goos` and `-goarch` flags to build the compiled binary for the target platform.  Valid values for these flags may be found here: https://golang.org/doc/install/source#environment.  The OS values are obvious (except darwin=MacOS), the GOARCH values most commonly needed will be "amd64" or "386" for 64 for 32 bit versions of common desktop OSes.
+If you intend to run the binary on another machine with a different OS platform, you may use the `-goos`, `-goarch` and `-goarm` flags to build the compiled binary for the target platform.  Valid values for these flags may be found here: https://golang.org/doc/install/source#environment.  The OS values are obvious (except darwin=MacOS), the GOARCH values most commonly needed will be "amd64" or "386" for 64 for 32 bit versions of common desktop OSes.
 
 Note that if you run `-compile` with `-dir`, the `-compile` target will be *relative to the magefile dir*.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -100,6 +100,7 @@ Options:
   -debug    turn on debug messages
   -f        force recreation of compiled magefile
   -goarch   sets the GOARCH for the binary created by -compile (default: current arch)
+	-goarm    sets the GOARM for the binary created by -compile (default: empty or current ARM version depending on arch)
   -gocmd <string>
 		    use the given go binary to compile the output (default: "go")
   -goos     sets the GOOS for the binary created by -compile (default: current OS)


### PR DESCRIPTION
Refers to question/issue #351 

It should all work nicely, although it adds that x/sys dependency to detect GOARM at runtime if it's not set, since it's not part of the `runtime` package. Maybe a better solution could be found. If we stick to that Golang solution, we may want to bump to Go 1.16 to have the latest x/sys dependency perhaps.