### PR TITLE
feat: add ability to skip importing target

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -18,6 +18,7 @@ import (
 )
 
 const importTag = "mage:import"
+const skipTarget = "mage:skip"
 
 var debug = log.New(ioutil.Discard, "DEBUG: ", log.Ltime|log.Lmicroseconds)
 
@@ -359,6 +360,10 @@ func setFuncs(pi *PkgInfo) {
 		debug.Printf("found target %v", f.Name)
 		fn.Name = f.Name
 		fn.Comment = toOneLine(f.Doc)
+		if fn.Comment == skipTarget {
+			debug.Printf("skipping function %s with skip comment", f.Name)
+			continue
+		}
 		fn.Synopsis = sanitizeSynopsis(f)
 		pi.Funcs = append(pi.Funcs, fn)
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -87,6 +87,12 @@ func TestParse(t *testing.T) {
 		t.Fatalf("expected to only have two aliases, but have %#v", info.Aliases)
 	}
 
+	for _, fn := range info.Funcs {
+		if fn.Name == "SkipTarget" {
+			t.Fatalf("expected %s to be skipped", fn.Name)
+		}
+	}
+
 	for _, fn := range expected {
 		found := false
 		for _, infoFn := range info.Funcs {

--- a/parse/testdata/command.go
+++ b/parse/testdata/command.go
@@ -31,3 +31,8 @@ func TakesContextReturnsVoid(ctx context.Context) {
 func TakesContextReturnsError(ctx context.Context) error {
 	return nil
 }
+
+// mage:skip
+func SkipTarget() {
+	mg.Deps(f)
+}


### PR DESCRIPTION
Potential solution for some of the problems mentioned in https://github.com/magefile/mage/issues/209

With this PR we can have functions in packages that we import, that are more support functions but not necessarily mage targets. `skip` might not be clear enough, we could also go for something like `noExport` or `excludeTarget`..

- [x] Add test
- [ ] Add documentation