### PR TITLE
Add asdf installation instructions to docs

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -42,6 +42,27 @@ The mage binary will be created in your $GOPATH/bin directory.
 You may also install a binary release from our
 [releases](https://github.com/magefile/mage/releases) page. 
 
+**Using asdf**
+
+The [asdf version manager](https://asdf-vm.com/) is a tool for installing release binaries from Github. With asdf installed, the [asdf plugin for mage](https://github.com/mathew-fleisch/asdf-mage) can be used to install any released version of mage.
+
+```shell
+# Install asdf plugin for mage
+asdf plugin add mage
+
+# Show all installable versions
+asdf list-all mage
+
+# Install specific version
+asdf install mage latest
+
+# Set a version globally (on your ~/.tool-versions file)
+asdf global mage latest
+
+# Now mage commands are available
+mage --version
+```
+
 ## Example Magefile
 
 ```go

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -62,20 +62,9 @@ See [scoop](https://scoop.sh/).
 The [asdf version manager](https://asdf-vm.com/) is a tool for installing release binaries from Github. With asdf installed, the [asdf plugin for mage](https://github.com/mathew-fleisch/asdf-mage) can be used to install any released version of mage.
 
 ```shell
-# Install asdf plugin for mage
 asdf plugin add mage
-
-# Show all installable versions
-asdf list-all mage
-
-# Install specific version
 asdf install mage latest
-
-# Set a version globally (on your ~/.tool-versions file)
 asdf global mage latest
-
-# Now mage commands are available
-mage --version
 ```
 
 ## Example Magefile

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -57,7 +57,7 @@ See [mage homebrew formula](https://formulae.brew.sh/formula/mage).
 
 See [scoop](https://scoop.sh/).
 
-**Using asdf**
+### Using asdf
 
 The [asdf version manager](https://asdf-vm.com/) is a tool for installing release binaries from Github. With asdf installed, the [asdf plugin for mage](https://github.com/mathew-fleisch/asdf-mage) can be used to install any released version of mage.
 


### PR DESCRIPTION
The [asdf version manager](https://asdf-vm.com/) is a tool for installing release binaries from Github. With asdf installed, the [asdf plugin for mage](https://github.com/mathew-fleisch/asdf-mage) can be used to install any released version of mage.

Please let me know if there is anything else I can do for this PR.

PS: Also willing to transfer ownership of the plugin if that is desirable to the community