### PR TITLE
Fix goreleaser config so that it conforms to new standard

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,8 @@ build:
       goarm: 6
   env:
     - CGO_ENABLED=0
-archive:
+archives:
+- 
   name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
   replacements:
     amd64: 64bit


### PR DESCRIPTION
The goreleaser config hadn't been updated in years, but I never updated goreleaser on my local machine, so it continued to work. Now I have updated both.