### PR TITLE
feat: allow mage:import alias to be defined for multiple imports

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -312,3 +312,57 @@ Error parsing magefiles: error running "go list -f {{.Dir}}||{{.Name}} github.co
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actualShortened)
 	}
 }
+
+func TestMageImportsSameNamespaceUniqueTargets(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport/samenamespace/uniquetargets",
+		Stdout: stdout,
+		Stderr: stderr,
+		List:   true,
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := `
+Targets:
+  samenamespace:build1    
+  samenamespace:build2    
+`[1:]
+
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}
+
+func TestMageImportsSameNamespaceDupTargets(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport/samenamespace/duptargets",
+		Stdout: stdout,
+		Stderr: stderr,
+		List:   true,
+	}
+
+	code := Invoke(inv)
+	if code != 1 {
+		t.Fatalf("expected to exit with code 1, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stderr.String()
+	expected := `
+Error parsing magefiles: "samenamespace:build" target has multiple definitions: github.com/magefile/mage/mage/testdata/mageimport/samenamespace/duptargets/package1.Build, github.com/magefile/mage/mage/testdata/mageimport/samenamespace/duptargets/package2.Build
+
+`[1:]
+	if actual != expected {
+		t.Logf("expected: %q", expected)
+		t.Logf("  actual: %q", actual)
+		t.Fatalf("expected:\n%v\n\ngot:\n%v", expected, actual)
+	}
+}

--- a/mage/testdata/mageimport/samenamespace/duptargets/magefile.go
+++ b/mage/testdata/mageimport/samenamespace/duptargets/magefile.go
@@ -1,0 +1,10 @@
+// +build mage
+
+package sametarget
+
+import (
+	// mage:import samenamespace
+	_ "github.com/magefile/mage/mage/testdata/mageimport/samenamespace/duptargets/package1"
+	// mage:import samenamespace
+	_ "github.com/magefile/mage/mage/testdata/mageimport/samenamespace/duptargets/package2"
+)

--- a/mage/testdata/mageimport/samenamespace/duptargets/package1/package1.go
+++ b/mage/testdata/mageimport/samenamespace/duptargets/package1/package1.go
@@ -1,0 +1,7 @@
+package package1
+
+import "fmt"
+
+func Build() {
+	fmt.Println("build")
+}

--- a/mage/testdata/mageimport/samenamespace/duptargets/package2/package2.go
+++ b/mage/testdata/mageimport/samenamespace/duptargets/package2/package2.go
@@ -1,0 +1,7 @@
+package package2
+
+import "fmt"
+
+func Build() {
+	fmt.Println("build")
+}

--- a/mage/testdata/mageimport/samenamespace/uniquetargets/magefile.go
+++ b/mage/testdata/mageimport/samenamespace/uniquetargets/magefile.go
@@ -1,0 +1,10 @@
+// +build mage
+
+package main
+
+import (
+	// mage:import samenamespace
+	_ "github.com/magefile/mage/mage/testdata/mageimport/samenamespace/uniquetargets/package1"
+	// mage:import samenamespace
+	_ "github.com/magefile/mage/mage/testdata/mageimport/samenamespace/uniquetargets/package2"
+)

--- a/mage/testdata/mageimport/samenamespace/uniquetargets/package1/package1.go
+++ b/mage/testdata/mageimport/samenamespace/uniquetargets/package1/package1.go
@@ -1,0 +1,7 @@
+package package1
+
+import "fmt"
+
+func Build1() {
+	fmt.Println("build")
+}

--- a/mage/testdata/mageimport/samenamespace/uniquetargets/package2/package2.go
+++ b/mage/testdata/mageimport/samenamespace/uniquetargets/package2/package2.go
@@ -1,0 +1,7 @@
+package package2
+
+import "fmt"
+
+func Build2() {
+	fmt.Println("build")
+}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -267,7 +267,7 @@ func Package(path string, files []string) (*PkgInfo, error) {
 
 func getNamedImports(gocmd string, pkgs map[string]string) ([]*Import, error) {
 	var imports []*Import
-	for alias, pkg := range pkgs {
+	for pkg, alias := range pkgs {
 		debug.Printf("getting import package %q, alias %q", pkg, alias)
 		imp, err := getImport(gocmd, pkg, alias)
 		if err != nil {
@@ -411,10 +411,7 @@ func setImports(gocmd string, pi *PkgInfo) error {
 				}
 				if alias != "" {
 					debug.Printf("found %s: %s (%s)", importTag, name, alias)
-					if importNames[alias] != "" {
-						return fmt.Errorf("duplicate import alias: %q", alias)
-					}
-					importNames[alias] = name
+					importNames[name] = alias
 				} else {
 					debug.Printf("found %s: %s", importTag, name)
 					rootImports = append(rootImports, name)


### PR DESCRIPTION
When testing this locally, I haven't been able to trigger any collisions that isnt already flagged by the existing sanity checks. So far everything has just worked as expected, all existing tests are passing.  

Documentation wise, I couldnt find anything that actually specifies that the an import alias needs to be unique, so I dont feel we need to add something there