### PR TITLE
chore: wrap log.Println in cmd with verbose check

### DIFF
--- a/sh/cmd.go
+++ b/sh/cmd.go
@@ -137,7 +137,10 @@ func run(env map[string]string, stdout, stderr io.Writer, cmd string, args ...st
 	for i := range args {
 		quoted = append(quoted, fmt.Sprintf("%q", args[i]));
 	}
-	log.Println("exec:", cmd,  strings.Join(quoted, " "))
+	// To protect against logging from doing exec in global variables
+	if mg.Verbose() {
+		log.Println("exec:", cmd, strings.Join(quoted, " "))
+	}
 	err = c.Run()
 	return CmdRan(err), ExitStatus(err), err
 }


### PR DESCRIPTION
~~This was introduced in https://github.com/magefile/mage/pull/306 it feels like it was left there by mistake. Its causing a lot of unwanted log prints~~

Edit: This is triggered from doing `sh.Output/Run etc...` in a global variable. 