### PR TITLE
Add job to run the release and sign the release with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+        description: 'Release tag'
+
+jobs:
+  cut-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/setup-go@v2.2.0
+      with:
+        go-version: 1.17.x
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v2.1.0
+
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v2.9.1
+      with:
+        install-only: true
+
+    - uses: actions/checkout@v2
+
+    - name: Config git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Mage Release
+      run: go run main.go release ${{ github.event.inputs.release_tag }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,14 @@
 project_name: mage
+
+env:
+  - COSIGN_EXPERIMENTAL=true
+
 release:
   github:
     owner: magefile
     name: mage
   draft: true
+
 build:
   binary: mage
   main: .
@@ -26,9 +31,9 @@ build:
       goarm: 6
   env:
     - CGO_ENABLED=0
+
 archives:
-- 
-  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+- name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
   replacements:
     amd64: 64bit
     386: 32bit
@@ -47,7 +52,17 @@ archives:
       format: zip
   files:
   - LICENSE
+
+signs:
+  - id: all
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    cmd: cosign
+    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
+    artifacts: all
+
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}
+
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'


### PR DESCRIPTION
- add a job to cut a release on-demand using `workflow_dispatch`
- sign the artifacts with cosign

Fixes: #403 

A rehearsal of the release running with GitHub actions and the signing part

- https://github.com/cpanato/mage/releases/tag/v1.99.99
- https://github.com/cpanato/mage/runs/5662096376?check_suite_focus=true