### PR TITLE
add version info automatically if you build with go 1.18+

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -66,13 +66,6 @@ const (
 
 var debug = log.New(ioutil.Discard, "DEBUG: ", log.Ltime|log.Lmicroseconds)
 
-// set by ldflags when you "mage build"
-var (
-	commitHash = "<not set>"
-	timestamp  = "<not set>"
-	gitTag     = "<not set>"
-)
-
 //go:generate stringer -type=Command
 
 // Command tracks invocations of mage that run without targets or other flags.
@@ -146,8 +139,8 @@ func ParseAndRun(stdout, stderr io.Writer, stdin io.Reader, args []string) int {
 
 	switch cmd {
 	case Version:
-		out.Println("Mage Build Tool", gitTag)
-		out.Println("Build Date:", timestamp)
+		out.Println("Mage Build Tool", getTag())
+		out.Println("Commit Date:", timestamp)
 		out.Println("Commit:", commitHash)
 		out.Println("built with:", runtime.Version())
 		return 0

--- a/mage/version.go
+++ b/mage/version.go
@@ -1,0 +1,86 @@
+//go:build go1.18
+
+package mage
+
+import (
+	"encoding/json"
+	"net/http"
+	dbg "runtime/debug"
+	"sort"
+	"strings"
+	"time"
+)
+
+// set by ldflags when you "mage build"
+var (
+	commitHash = "<not set>"
+	timestamp  = "<not set>"
+	gitTag     = "<not set>"
+)
+
+func init() {
+	info, ok := dbg.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, kv := range info.Settings {
+		switch kv.Key {
+		case "vcs.revision":
+			commitHash = kv.Value
+		case "vcs.time":
+			timestamp = kv.Value
+		}
+	}
+}
+
+// uses the commit hash to get the git tag (if one exists) from github
+func getTag() string {
+	debug.Println("requesting tag info from github via https://api.github.com/repos/magefile/mage/git/refs/tags")
+
+	http.DefaultClient.Timeout = 300 * time.Millisecond
+	resp, err := http.DefaultClient.Get("https://api.github.com/repos/magefile/mage/git/refs/tags")
+	if err != nil {
+		debug.Println("unable to request tag info from github:", err)
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		debug.Println("bad response requesting mage tag info from github:", resp.StatusCode)
+		return ""
+	}
+
+	var tags []tag
+	err = json.NewDecoder(resp.Body).Decode(&tags)
+	if err != nil {
+		debug.Println("error unmarshalling mage tag info from github:", err)
+		return ""
+	}
+
+	var found []string
+	for _, t := range tags {
+		if t.Object.Sha == commitHash && strings.HasPrefix(t.Ref, "refs/tags/") {
+			found = append(found, t.Ref[len("refs/tags/"):])
+		}
+	}
+	if len(found) == 0 {
+		debug.Println("no git tag found for commit hash:", commitHash)
+		return "<no tag for this commit>"
+	}
+	if len(found) == 1 {
+		return found[0]
+	}
+	// more than one tag for this commit, report the highest tag number.
+	sort.Strings(found)
+	return found[len(found)-1]
+}
+
+type tag struct {
+	Ref    string `json:"ref"`
+	NodeID string `json:"node_id"`
+	URL    string `json:"url"`
+	Object struct {
+		Sha  string `json:"sha"`
+		Type string `json:"type"`
+		URL  string `json:"url"`
+	} `json:"object"`
+}

--- a/mage/version_old.go
+++ b/mage/version_old.go
@@ -1,0 +1,14 @@
+//go:build !go1.18
+
+package mage
+
+// set by ldflags when you "mage build"
+var (
+	commitHash = "<not set>"
+	timestamp  = "<not set>"
+	gitTag     = ""
+)
+
+func getTag() string {
+	return gitTag
+}


### PR DESCRIPTION
The only reason we have an install script is to set build data. As of 1.18, we don't need that anymore. So, now the logic will be split, if you have 1.18, you can just do `go install github.com/magefile/mage@latest` and it'll Just Work™.

If you have go 1.17.x or earlier, you'll still need to run `go run install.go` to have the local mage binary report version info.

One slight suboptimalness (that's a word, I swear) of the 1.18 data is that it doesn't include tag info, only commit info. That's not very user-friendly, so I wrote code to get tag info from github... which means `mage --version` has to go out to the internet if it was build with 1.18. That stinks, but I think it's worth it if it means `go install` mostly just works.