### PR TITLE
doc: add MacPorts install info

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -51,6 +51,12 @@ You may also install a binary release from our
 
 See [mage homebrew formula](https://formulae.brew.sh/formula/mage).
 
+### With MacPorts (MacOS)
+
+`sudo port install mage`
+
+See [port page](https://ports.macports.org/port/mage/)
+
 ### With Scoop (Windows)
 
 `scoop install mage`


### PR DESCRIPTION
`mage` is now available in [MacPorts](https://www.macports.org/)

https://ports.macports.org/port/mage/