### PR TITLE
feat: rename templated imports to avoid collisions

### DIFF
--- a/mage/template.go
+++ b/mage/template.go
@@ -9,16 +9,16 @@ package main
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"io/ioutil"
-	"log"
+	_flag "flag"
+	_fmt "fmt"
+	_ioutil "io/ioutil"
+	_log "log"
 	"os"
-	"path/filepath"
-	"sort"
+	_filepath "path/filepath"
+	_sort "sort"
 	"strconv"
-	"strings"
-	"text/tabwriter"
+	_strings "strings"
+	_tabwriter "text/tabwriter"
 	"time"
 	{{range .Imports}}{{.UniqueName}} "{{.Path}}"
 	{{end}}
@@ -41,7 +41,7 @@ func main() {
 		}		
 		b, err := strconv.ParseBool(val)
 		if err != nil {
-			log.Printf("warning: environment variable %s is not a valid bool value: %v", env, val)
+			_log.Printf("warning: environment variable %s is not a valid bool value: %v", env, val)
 			return false
 		}
 		return b
@@ -54,13 +54,13 @@ func main() {
 		}		
 		d, err := time.ParseDuration(val)
 		if err != nil {
-			log.Printf("warning: environment variable %s is not a valid duration value: %v", env, val)
+			_log.Printf("warning: environment variable %s is not a valid duration value: %v", env, val)
 			return 0
 		}
 		return d
 	}
 	args := arguments{}
-	fs := flag.FlagSet{}
+	fs := _flag.FlagSet{}
 	fs.SetOutput(os.Stdout)
 
 	// default flag set with ExitOnError and auto generated PrintDefaults should be sufficient
@@ -69,7 +69,7 @@ func main() {
 	fs.BoolVar(&args.Help, "h", parseBool("MAGEFILE_HELP"), "print out help for a specific target")
 	fs.DurationVar(&args.Timeout, "t", parseDuration("MAGEFILE_TIMEOUT"), "timeout in duration parsable format (e.g. 5m30s)")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stdout, ` + "`" + `
+		_fmt.Fprintf(os.Stdout, ` + "`" + `
 %s [options] [target]
 
 Commands:
@@ -81,7 +81,7 @@ Options:
   -t <string>
         timeout in duration parsable format (e.g. 5m30s)
   -v    show verbose output when running targets
- ` + "`" + `[1:], filepath.Base(os.Args[0]))
+ ` + "`" + `[1:], _filepath.Base(os.Args[0]))
 	}
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		// flag will have printed out an error already.
@@ -157,7 +157,7 @@ Options:
 	var defaultTargetAnsiColor = ansiColor[cyan]
 
 	getAnsiColor := func(color string) (string, bool) {
-		colorLower := strings.ToLower(color)
+		colorLower := _strings.ToLower(color)
 		for k, v := range ansiColor {
 			colorConstLower := colorToLowerString(k)
 			if colorConstLower == colorLower {
@@ -214,14 +214,14 @@ Options:
 
 	printName := func(str string) string {
 		if enableColorValue {
-			return fmt.Sprintf("%s%s%s", targetColorValue, str, ansiColorReset)
+			return _fmt.Sprintf("%s%s%s", targetColorValue, str, ansiColorReset)
 		} else {
 			return str
 		}
 	}
 
 	list := func() error {
-		{{with .Description}}fmt.Println(` + "`{{.}}\n`" + `)
+		{{with .Description}}_fmt.Println(` + "`{{.}}\n`" + `)
 		{{- end}}
 		{{- $default := .DefaultFunc}}
 		targets := map[string]string{
@@ -239,17 +239,17 @@ Options:
 		for name := range targets {
 			keys = append(keys, name)
 		}
-		sort.Strings(keys)
+		_sort.Strings(keys)
 
-		fmt.Println("Targets:")
-		w := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
+		_fmt.Println("Targets:")
+		w := _tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
 		for _, name := range keys {
-			fmt.Fprintf(w, "  %v\t%v\n", printName(name), targets[name])
+			_fmt.Fprintf(w, "  %v\t%v\n", printName(name), targets[name])
 		}
 		err := w.Flush()
 		{{- if .DefaultFunc.Name}}
 			if err == nil {
-				fmt.Println("\n* default target")
+				_fmt.Println("\n* default target")
 			}
 		{{- end}}
 		return err
@@ -288,7 +288,7 @@ Options:
 		case <-ctx.Done():
 			cancel()
 			e := ctx.Err()
-			fmt.Printf("ctx err: %v\n", e)
+			_fmt.Printf("ctx err: %v\n", e)
 			return e
 		case err = <-d:
 			cancel()
@@ -299,7 +299,7 @@ Options:
 	// variable error.
 	_ = runTarget
 
-	handleError := func(logger *log.Logger, err interface{}) {
+	handleError := func(logger *_log.Logger, err interface{}) {
 		if err != nil {
 			logger.Printf("Error: %+v\n", err)
 			type code interface {
@@ -320,14 +320,14 @@ Options:
 		os.Setenv("MAGEFILE_VERBOSE", "0")
 	}
 
-	log.SetFlags(0)
+	_log.SetFlags(0)
 	if !args.Verbose {
-		log.SetOutput(ioutil.Discard)
+		_log.SetOutput(_ioutil.Discard)
 	}
-	logger := log.New(os.Stderr, "", 0)
+	logger := _log.New(os.Stderr, "", 0)
 	if args.List {
 		if err := list(); err != nil {
-			log.Println(err)
+			_log.Println(err)
 			os.Exit(1)
 		}
 		return
@@ -338,14 +338,14 @@ Options:
 			logger.Println("no target specified")
 			os.Exit(2)
 		}
-		switch strings.ToLower(args.Args[0]) {
+		switch _strings.ToLower(args.Args[0]) {
 			{{range .Funcs -}}
 			case "{{lower .TargetName}}":
 				{{if ne .Comment "" -}}
-				fmt.Println({{printf "%q" .Comment}})
-				fmt.Println()
+				_fmt.Println({{printf "%q" .Comment}})
+				_fmt.Println()
 				{{end}}
-				fmt.Print("Usage:\n\n\t{{$.BinaryName}} {{lower .TargetName}}{{range .Args}} <{{.Name}}>{{end}}\n\n")
+				_fmt.Print("Usage:\n\n\t{{$.BinaryName}} {{lower .TargetName}}{{range .Args}} <{{.Name}}>{{end}}\n\n")
 				var aliases []string
 				{{- $name := .Name -}}
 				{{- $recv := .Receiver -}}
@@ -353,7 +353,7 @@ Options:
 				{{if and (eq $name $func.Name) (eq $recv $func.Receiver)}}aliases = append(aliases, "{{$alias}}"){{end -}}
 				{{- end}}
 				if len(aliases) > 0 {
-					fmt.Printf("Aliases: %s\n\n", strings.Join(aliases, ", "))
+					_fmt.Printf("Aliases: %s\n\n", _strings.Join(aliases, ", "))
 				}
 				return
 			{{end -}}
@@ -361,10 +361,10 @@ Options:
 				{{range .Info.Funcs -}}
 			case "{{lower .TargetName}}":
 				{{if ne .Comment "" -}}
-				fmt.Println({{printf "%q" .Comment}})
-				fmt.Println()
+				_fmt.Println({{printf "%q" .Comment}})
+				_fmt.Println()
 				{{end}}
-				fmt.Print("Usage:\n\n\t{{$.BinaryName}} {{lower .TargetName}}{{range .Args}} <{{.Name}}>{{end}}\n\n")
+				_fmt.Print("Usage:\n\n\t{{$.BinaryName}} {{lower .TargetName}}{{range .Args}} <{{.Name}}>{{end}}\n\n")
 				var aliases []string
 				{{- $name := .Name -}}
 				{{- $recv := .Receiver -}}
@@ -372,7 +372,7 @@ Options:
 				{{if and (eq $name $func.Name) (eq $recv $func.Receiver)}}aliases = append(aliases, "{{$alias}}"){{end -}}
 				{{- end}}
 				if len(aliases) > 0 {
-					fmt.Printf("Aliases: %s\n\n", strings.Join(aliases, ", "))
+					_fmt.Printf("Aliases: %s\n\n", _strings.Join(aliases, ", "))
 				}
 				return
 				{{end -}}
@@ -408,14 +408,14 @@ Options:
 		x++
 
 		// resolve aliases
-		switch strings.ToLower(target) {
+		switch _strings.ToLower(target) {
 		{{range $alias, $func := .Aliases}}
 			case "{{lower $alias}}":
 				target = "{{$func.TargetName}}"
 		{{- end}}
 		}
 
-		switch strings.ToLower(target) {
+		switch _strings.ToLower(target) {
 		{{range .Funcs }}
 			case "{{lower .TargetName}}":
 				expected := x + {{len .Args}}


### PR DESCRIPTION
Addresses #286

This PR renames most imports in the template to minimise the risk of collisions.
Some imports (like `context`) may need to remain pure, for generated `wrapFuncs` to function properly (unless this also merits changing).