### PR TITLE
feat: Nested Namespaces

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -55,6 +55,24 @@ func TestParse(t *testing.T) {
 			Receiver: "Build",
 			IsError:  false,
 		},
+		{
+			Name:            "Foo",
+			Receiver:        "Nested",
+			ReceiverParents: []string{"Init"},
+			IsError:         true,
+		},
+		{
+			Name:            "Bar",
+			Receiver:        "Nested",
+			ReceiverParents: []string{"Init"},
+			IsError:         false,
+		},
+		{
+			Name:            "Foobar",
+			Receiver:        "DoubleNested",
+			ReceiverParents: []string{"Init", "Nested"},
+			IsError:         true,
+		},
 	}
 
 	if info.DefaultFunc == nil {

--- a/parse/testdata/subcommands.go
+++ b/parse/testdata/subcommands.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main
@@ -19,5 +20,23 @@ type Init mg.Namespace
 
 func (Init) Foobar() error {
 	// do your foobar defined in init namespace
+	return nil
+}
+
+type Nested Init
+
+func (Nested) Foo() error {
+	// do your foo defined in init:nested namespace
+	return nil
+}
+
+func (Nested) Bar() {
+	// do your bar defined in init:nested namespace
+}
+
+type DoubleNested Nested
+
+func (DoubleNested) Foobar() error {
+	// do your foobar defined in init:nested:doublenested namespace
 	return nil
 }


### PR DESCRIPTION
Provide the ability to nest namespaces by defining a type that transitively is a mg.Namespace.

Namespaces can have functions named the same as a sub-namespace.

An example magefile:
```go
type Docker mg.Namespace

func (Docker) Build() { fmt.Println("docker:build") }

type Developer Docker

func (Developer) Build() { fmt.Println("docker:developer:build") }

type CI Docker

func (CI) Build() { fmt.Println("docker:ci:build") }
```

Results in the following:
```
Targets:
  docker:build              
  docker:ci:build           
  docker:developer:build    
```

Closes #152

This does not implement nested/transitive imports, only namespaces.