### PR TITLE
Showing panic trace on debug mode

### DIFF
--- a/mage/template.go
+++ b/mage/template.go
@@ -9,6 +9,8 @@ package main
 
 import (
 	"context"
+	_runtime_debug "runtime/debug"
+	_errors "errors"
 	_flag "flag"
 	_fmt "fmt"
 	_ioutil "io/ioutil"
@@ -279,7 +281,12 @@ Options:
 		go func() {
 			defer func() {
 				err := recover()
-				d <- err
+				isDebug, _ := strconv.ParseBool(os.Getenv("MAGEFILE_DEBUG"))
+				if isDebug {
+					d <- _errors.New(string(_runtime_debug.Stack()))
+				} else {
+					d <- err
+				}
 			}()
 			err := fn(ctx)
 			d <- err


### PR DESCRIPTION
It enables the hability to show the whole trace for panic errors inside your
magefile when you are in debug mode. If you are not in debug mode, the behavior
keeps the same.

Fixes #333