### PR TITLE
Proposal for binary cache cleanup

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -510,8 +510,7 @@ func cleanCache(cacheDir string) error {
 		totalSize += f.Size()
 		if maxCacheAge > 0 && timeLimit.After(f.ModTime()) {
 			os.Remove(filepath.Join(cacheDir, f.Name()))
-		}
-		if maxCacheSize > 0 && totalSize > maxCacheSize {
+		} else if maxCacheSize > 0 && totalSize > maxCacheSize {
 			os.Remove(filepath.Join(cacheDir, f.Name()))
 		}
 	}

--- a/site/content/environment/_index.en.md
+++ b/site/content/environment/_index.en.md
@@ -73,3 +73,23 @@ The supported ANSI color names are any of these:
 - BrightWhite
 
 The names are case-insensitive.
+
+## MAGE_NOCACHE
+
+Set to "1" or "true" to turn off the binary cache
+
+## MAGEFILE_MAX_CACHE_SIZE
+
+Set to the number of bytes that you want to keep in the binary caches.
+
+Default value: 200000000
+
+## MAGEFILE_MAX_CACHE_AGE
+
+Set to the number of days that you want to keep binary caches.
+
+Default value: 10
+
+## MAGEFILE_AUTOCLENAUP
+
+Set to "0" or "false" to turn off the binary cache cleanup process

--- a/site/content/howitworks/_index.en.md
+++ b/site/content/howitworks/_index.en.md
@@ -17,6 +17,10 @@ binary is also used in the hash.
 Compiled magefile binaries are stored in $HOME/.magefile.  This location can be
 customized by setting the MAGEFILE_CACHE environment variable.
 
+You can disable or adjust your binary cache using the MAGE_NOCACHE,
+MAGEFILE_AUTOCLEANUP, MAGEFILE_MAX_CACHE_SIZE and MAGEFILE_MAX_CACHE_AGE
+environment variables.
+
 ## Go Environment
 
 Mage itself requires no dependencies to run. However, because it is compiling go


### PR DESCRIPTION
This PR is a proposal to implement the cache auto-cleanup functionality using the environment variables suggested.

I have some doubts about how to define things there. I think the variables have 2 different granularity. For example, the size in bytes, makes no sense to me, because the go binaries are going to be around 2MB in the best case, so... would make more sense to use MB instead of bytes to measure that value. The age in days, sounds ok, not a big deal, but maybe we want more granularity there (or not).

Also, I did a "touch" of the binary files in every execution to use that information as part of the cleanup process, that way I can store in the filesystem if I need to clean up that or not.

Fixes #319