### PR TITLE
Adding kebab case target option

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -31,31 +30,8 @@ import (
 // change the inputs to the compiling process.
 const magicRebuildKey = "v0.3"
 
-// (Aaaa)(Bbbb) -> aaaaBbbb
-var firstWordRx = regexp.MustCompile(`^([[:upper:]][^[:upper:]]+)([[:upper:]].*)$`)
-
-// (AAAA)(Bbbb) -> aaaaBbbb
-var firstAbbrevRx = regexp.MustCompile(`^([[:upper:]]+)([[:upper:]][^[:upper:]].*)$`)
-
-func lowerFirstWord(s string) string {
-	if match := firstWordRx.FindStringSubmatch(s); match != nil {
-		return strings.ToLower(match[1]) + match[2]
-	}
-	if match := firstAbbrevRx.FindStringSubmatch(s); match != nil {
-		return strings.ToLower(match[1]) + match[2]
-	}
-	return strings.ToLower(s)
-}
-
 var mainfileTemplate = template.Must(template.New("").Funcs(map[string]interface{}{
 	"lower": strings.ToLower,
-	"lowerFirst": func(s string) string {
-		parts := strings.Split(s, ":")
-		for i, t := range parts {
-			parts[i] = lowerFirstWord(t)
-		}
-		return strings.Join(parts, ":")
-	},
 }).Parse(mageMainfileTplString))
 var initOutput = template.Must(template.New("").Parse(mageTpl))
 

--- a/mage/main.go
+++ b/mage/main.go
@@ -460,12 +460,13 @@ func Invoke(inv Invocation) int {
 }
 
 type mainfileTemplateData struct {
-	Description string
-	Funcs       []*parse.Function
-	DefaultFunc parse.Function
-	Aliases     map[string]*parse.Function
-	Imports     []*parse.Import
-	BinaryName  string
+	Description     string
+	Funcs           []*parse.Function
+	DefaultFunc     parse.Function
+	Aliases         map[string]*parse.Function
+	Imports         []*parse.Import
+	BinaryName      string
+	UseKebabTargets bool
 }
 
 func listGoFiles(magePath, goCmd, tags string, env []string) ([]string, error) {
@@ -599,11 +600,12 @@ func GenerateMainfile(binaryName, path string, info *parse.PkgInfo) error {
 	}
 	defer f.Close()
 	data := mainfileTemplateData{
-		Description: info.Description,
-		Funcs:       info.Funcs,
-		Aliases:     info.Aliases,
-		Imports:     info.Imports,
-		BinaryName:  binaryName,
+		Description:     info.Description,
+		Funcs:           info.Funcs,
+		Aliases:         info.Aliases,
+		Imports:         info.Imports,
+		BinaryName:      binaryName,
+		UseKebabTargets: info.UseKebabTargets,
 	}
 
 	if info.DefaultFunc != nil {

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -342,6 +342,27 @@ func TestMixedMageImports(t *testing.T) {
 	}
 }
 
+func TestKebabCaseTargets(t *testing.T) {
+	resetTerm()
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/kebab_targets",
+		Stdout: stdout,
+		Stderr: stderr,
+		List:   true,
+	}
+	code := Invoke(inv)
+	if code != 0 {
+		t.Errorf("expected to exit with code 0, but got %v, stderr: %s", code, stderr)
+	}
+	expected := "Targets:\n  multi-word-namespace:multi-word-task    \n  multi-word-task                         \n"
+	actual := stdout.String()
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
 func TestMagefilesFolder(t *testing.T) {
 	resetTerm()
 	wd, err := os.Getwd()

--- a/mage/testdata/kebab_targets/kebab_targets.go
+++ b/mage/testdata/kebab_targets/kebab_targets.go
@@ -1,0 +1,29 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/magefile/mage/mg"
+)
+
+const UseKebabTargets = true
+
+type MultiWordNamespace mg.Namespace
+
+func (MultiWordNamespace) MultiWordTask() error {
+	fmt.Println("Running MultiWordNamespace.MultiWordTask")
+	return nil
+}
+
+func MultiWordTask() error {
+	fmt.Println("Running MultiWordTask")
+	return nil
+}
+
+var Aliases = map[string]interface{}{
+	"mwn:mwt": MultiWordNamespace.MultiWordTask,
+	"mwt":     MultiWordTask,
+}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 func TestParse(t *testing.T) {
-	info, err := PrimaryPackage("go", "./testdata", []string{"func.go", "command.go", "alias.go", "repeating_synopsis.go", "subcommands.go"})
+	info, err := PrimaryPackage("go", "./testdata", []string{"func.go", "command.go", "alias.go", "repeating_synopsis.go", "subcommands.go", "kebab_targets.go"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,6 +59,10 @@ func TestParse(t *testing.T) {
 
 	if info.DefaultFunc == nil {
 		t.Fatal("expected default func to exist, but was nil")
+	}
+
+	if info.UseKebabTargets != true {
+		t.Fatal("expected UseKebabTargest to be true")
 	}
 
 	// DefaultIsError

--- a/parse/testdata/kebab_targets.go
+++ b/parse/testdata/kebab_targets.go
@@ -1,0 +1,10 @@
+//go:build mage
+// +build mage
+
+package main
+
+const UseKebabTargets = true
+
+func Prueba() error {
+	return nil
+}


### PR DESCRIPTION
This allows us to define kebab case options. This takes into acount when you
list, when you run, when you print the help and when you use an alias, I don't
know if I'm missing something.

Fixes #311