### PR TITLE
refactor(listGoFiles): remove go list dependency

### DIFF
--- a/internal/run.go
+++ b/internal/run.go
@@ -57,9 +57,9 @@ func OutputDebug(cmd string, args ...string) (string, error) {
 	return strings.TrimSpace(buf.String()), nil
 }
 
-// splitEnv takes the results from os.Environ() (a []string of foo=bar values)
+// SplitEnv takes the results from os.Environ() (a []string of foo=bar values)
 // and makes a map[string]string out of it.
-func splitEnv(env []string) (map[string]string, error) {
+func SplitEnv(env []string) (map[string]string, error) {
 	out := map[string]string{}
 
 	for _, s := range env {
@@ -85,7 +85,7 @@ func joinEnv(env map[string]string) []string {
 // EnvWithCurrentGOOS returns a copy of os.Environ with the GOOS and GOARCH set
 // to runtime.GOOS and runtime.GOARCH.
 func EnvWithCurrentGOOS() ([]string, error) {
-	vals, err := splitEnv(os.Environ())
+	vals, err := SplitEnv(os.Environ())
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func EnvWithCurrentGOOS() ([]string, error) {
 // EnvWithGOOS retuns the os.Environ() values with GOOS and/or GOARCH either set
 // to their runtime value, or the given value if non-empty.
 func EnvWithGOOS(goos, goarch string) ([]string, error) {
-	env, err := splitEnv(os.Environ())
+	env, err := SplitEnv(os.Environ())
 	if err != nil {
 		return nil, err
 	}

--- a/mage/main.go
+++ b/mage/main.go
@@ -476,7 +476,7 @@ func listGoFiles(magePath, goCmd, tag string, envStr []string) ([]string, error)
 	if !filepath.IsAbs(magePath) {
 		cwd, err := os.Getwd()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("can't get current working directory: %v", err)
 		}
 		magePath = filepath.Join(cwd, magePath)
 	}

--- a/mage/main.go
+++ b/mage/main.go
@@ -506,7 +506,7 @@ func listGoFiles(magePath, goCmd, tag string, envStr []string) ([]string, error)
 
 		// Allow multiple packages in the same directory
 		if _, ok := err.(*build.MultiplePackageError); !ok {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse go source files: %v", err)
 		}
 	}
 

--- a/mage/main.go
+++ b/mage/main.go
@@ -483,7 +483,7 @@ func listGoFiles(magePath, goCmd, tag string, envStr []string) ([]string, error)
 
 	env, err := internal.SplitEnv(envStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing environment variables: %v", err)
 	}
 
 	bctx := build.Default

--- a/mage/main.go
+++ b/mage/main.go
@@ -487,7 +487,6 @@ func listGoFiles(magePath, goCmd, tag string, envStr []string) ([]string, error)
 	}
 
 	bctx := build.Default
-	bctx.Dir = magePath
 	bctx.BuildTags = []string{tag}
 
 	if _, ok := env["GOOS"]; ok {
@@ -498,7 +497,7 @@ func listGoFiles(magePath, goCmd, tag string, envStr []string) ([]string, error)
 		bctx.GOARCH = env["GOARCH"]
 	}
 
-	pkg, err := bctx.Import(".", bctx.Dir, 0)
+	pkg, err := bctx.Import(".", magePath, 0)
 	if err != nil {
 		if _, ok := err.(*build.NoGoError); ok {
 			return []string{}, nil


### PR DESCRIPTION
**What this PR does**: This PR removes the usage of `go list` in favor of parsing the files with the `go/build` package. This speeds up the discovery of go files from ms to us, which combined with `MAGEFILE_HASHFAST` can reduce the time for a re-run of `mage` to ~200ms.

I was getting a little irritated with every run of mage being _at least_ 500-600ms due to `go list` taking a min of `200ms` and being called twice, go list does a lot more then we were using it for. So, I propose we parse it instead.

**Notes for my reviewer**: I did this pretty quickly, and without that much regard for style. I'm happy to split this up and clean it up if we're OK with the approach. Thank you for reviewing :sparkles:

Related to https://github.com/magefile/mage/issues/404

### Performance Measurements

**This PR:**

```bash
$ MAGEFILE_HASHFAST=true hyperfine -i './bin/mage -debug -l'
Benchmark 1: ./bin/mage -debug -l
  Time (mean ± σ):     182.7 ms ±   7.7 ms    [User: 33.5 ms, System: 84.2 ms]
  Range (min … max):   171.9 ms … 199.5 ms    14 runs
```

**1.13.0:**

```bash
$ MAGEFILE_HASHFAST=true hyperfine -i "$HOME/.asdf/installs/mage/1.13.0/bin/mage -debug -l"
Benchmark 1: /Users/jaredallard/.asdf/installs/mage/1.13.0/bin/mage -debug -l
  Time (mean ± σ):     529.2 ms ±  12.7 ms    [User: 196.9 ms, System: 433.4 ms]
  Range (min … max):   507.8 ms … 555.5 ms    10 runs
```
