### PR TITLE
Added working directory and context support.

### DIFF
--- a/sh/testmain_test.go
+++ b/sh/testmain_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 var (
@@ -14,6 +15,7 @@ var (
 	stdout    string
 	exitCode  int
 	printVar  string
+	sleep     time.Duration
 )
 
 func init() {
@@ -23,6 +25,7 @@ func init() {
 	flag.StringVar(&stdout, "stdout", "", "")
 	flag.IntVar(&exitCode, "exit", 0, "")
 	flag.StringVar(&printVar, "printVar", "", "")
+	flag.DurationVar(&sleep, "sleep", 0, "")
 }
 
 func TestMain(m *testing.M) {
@@ -34,6 +37,11 @@ func TestMain(m *testing.M) {
 	}
 	if printVar != "" {
 		fmt.Println(os.Getenv(printVar))
+		return
+	}
+
+	if sleep != 0 {
+		time.Sleep(sleep)
 		return
 	}
 


### PR DESCRIPTION
This PR is an attempt to solve https://github.com/magefile/mage/issues/213

Added `sh.Command` struct to mirror `exec.Cmd` and allow configuring
`sh.Exec` options, instead of adding a new function that
can change the working directory.

A single configuration struct was chosen instead of options since
the struct aggregates all configuration options together.

Added current `sh.Exec` parameters to `sh.Command` as fields, and
mimicked current behavior.

Moved `sh.run` functionality to `sh.(*Command).run`, and updated
`sh.Exec` to use `sh.Command.Exec`.

Added `WorkingDir` field to change the command's working
directory.