### PR TITLE
Output Aliases when running `mage -l`

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -28,6 +28,9 @@ Targets:
   zz:buildSubdir2    Builds stuff.
   zz:ns:deploy2*     deploys stuff.
 
+Aliases:
+  nsd2    -> zz:ns:deploy2
+
 * default target
 `[1:]
 

--- a/mage/template.go
+++ b/mage/template.go
@@ -237,6 +237,12 @@ Options:
 		{{- end}}
 		}
 
+		aliases := map[string]string{
+		{{- range $k, $v := .Aliases}}
+			"{{ lowerFirst $k }}": "-> {{lowerFirst $v.TargetName}}",
+		{{- end}}
+		}
+
 		keys := make([]string, 0, len(targets))
 		for name := range targets {
 			keys = append(keys, name)
@@ -248,6 +254,25 @@ Options:
 		for _, name := range keys {
 			_fmt.Fprintf(w, "  %v\t%v\n", printName(name), targets[name])
 		}
+
+		if len(aliases) != 0 {
+			err := w.Flush()
+			if err != nil {
+				return err
+			}
+		
+			aliasKeys := make([]string, 0, len(aliases))
+			for name := range aliases {
+				aliasKeys = append(aliasKeys, name)
+			}
+			_sort.Strings(aliasKeys)
+
+			_fmt.Println("\nAliases:")
+			for _, name := range aliasKeys {
+				_fmt.Fprintf(w, "  %v\t%v\n", printName(name), aliases[name])
+			}
+		}
+
 		err := w.Flush()
 		{{- if .DefaultFunc.Name}}
 			if err == nil {


### PR DESCRIPTION
We use mage for a few projects, and noticed a minor discovery problem of the aliases we setup for our targets. While yes you can run `mage -h target` to see aliases, that's not an obvious command to know about.

I have added the output of Aliases and to what targetname they point to in the `mage -l` output. That way it is more easily discoverable.

If there are no aliases setup, the Aliases section won't show up. I used an actual go if block instead of as a template one as it made `err` variable management a bit simpler. But I can make adjustments if it is preferred.

No new tests were added as a bunch of existing tests would fail if `Aliases` always showed up, and the ImportLists test fails if it doesn't show up.

I can add additional tests if requested though.
