### PR TITLE
 refactor(compile): add trimpath to compile to remove local paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Session.vim
 
 # Hugo build lock
 .hugo_build.lock
+
+# output files should be ignored
+mage_out

--- a/mage/main.go
+++ b/mage/main.go
@@ -591,6 +591,8 @@ func Compile(goos, goarch, ldflags, magePath, goCmd, compileTo string, gofiles [
 		gofiles[i] = filepath.Base(gofiles[i])
 	}
 	buildArgs := []string{"build", "-o", compileTo}
+	// buildArgs = append(buildArgs, "-trimpath")
+
 	if ldflags != "" {
 		buildArgs = append(buildArgs, "-ldflags", ldflags)
 	}

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -73,6 +73,21 @@ asdf install mage latest
 asdf global mage latest
 ```
 
+### Using Aqua
+
+aqua is a declarative CLI Version Manager written in Go.
+You can install CLI tools and manage their versions with YAML declaratively.
+
+To add to a project tool config:
+
+```shell
+aqua init
+aqua generate -i mage
+aqua install
+```
+
+To add to a global `aqua.yaml`, add to the [global configuration](https://aquaproj.github.io/docs/tutorial-basics/global-config) and finally run `aqua install --all` for Mage to be installed.
+
 ## Example Magefile
 
 ```go
@@ -97,7 +112,7 @@ Run the above `Build` target by simply running `mage build` in the same director
 
 ## Magefiles directory
 
-If you create your Magefile or files within a directory named `magefiles` And there is no Magefile in your current directory, 
+If you create your Magefile or files within a directory named `magefiles` And there is no Magefile in your current directory,
 `mage` will default to the directory as the source for your targets while keeping the current directory as working one.
 
 The result is the equivalent of running `mage -d magefiles -w .`
@@ -133,7 +148,7 @@ Commands:
   -version  show version info for the mage binary
 
 Options:
-  -d <string> 
+  -d <string>
             directory to read magefiles from (default ".")
   -debug    turn on debug messages
   -f        force recreation of compiled magefile


### PR DESCRIPTION
- Include trimpath to ensure local filepaths from CI or developer don't get included in the produced artifact.
- This was added in Go 1.13, so not sure if there is something special to handle adding this flag only if go version > 1.13.

Go documentation on this:

> -trimpath
> remove all file system paths from the resulting executable.
> Instead of absolute file system paths, the recorded file names
> will begin either a module path@version (when using modules),
> or a plain import path (when using the standard library, or GOPATH).
