### PR TITLE
docs: Add winget installation on Windows

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -63,6 +63,13 @@ See [port page](https://ports.macports.org/port/mage/)
 
 See [scoop](https://scoop.sh/).
 
+
+### With winget (Windows)
+
+`winget install Magefile.mage`
+
+See [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).
+
 ### Using asdf
 
 The [asdf version manager](https://asdf-vm.com/) is a tool for installing release binaries from Github. With asdf installed, the [asdf plugin for mage](https://github.com/mathew-fleisch/asdf-mage) can be used to install any released version of mage.


### PR DESCRIPTION
Mage 1.14.0 package has been accepted to [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) repository, see https://github.com/microsoft/winget-pkgs/pull/102752

----

It should be available shortly, and findable `winget search Magefile`.