### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.18.x
+          - tip
+          - 1.20.x
+          - 1.19.x
           - 1.17.x
           - 1.16.x
           - 1.15.x
@@ -18,9 +20,9 @@ jobs:
           - 1.12.x
           - 1.11.x
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - tip
+          - stable
           - 1.20.x
           - 1.19.x
           - 1.17.x


### PR DESCRIPTION
Using newest versions of checkout and setup go, as well as adding tip and newest versions of go.