### PR TITLE
docs: Add installation with go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ and Mage automatically uses them as Makefile-like runnable targets.
 Mage has no dependencies outside the Go standard library, and builds with Go 1.7
 and above (possibly even lower versions, but they're not regularly tested).
 
+```
+go install github.com/magefile/mage@latest
+```
+
 **Using GOPATH**
 
 ```


### PR DESCRIPTION
I'm a Go newbie who followed the `GOPATH` installation from within `$HOME` on Linux machine, and I got this:

```
$ cd ~ 
$ go get -u -d github.com/magefile/mage
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'
```

Then, I tried the suggestion:

```
$ go install github.com/magefile/mage@latest
go: downloading github.com/magefile/mage v1.15.0
```

which was simplest, clear and worked like a charm:

```
$ mage --version
Mage Build Tool <not set>
Build Date: <not set>
Commit: <not set>
built with: go1.20.4
```

so, IMHO, the `go install` way should be promoted as the recommended installation of `mage` tool.