### PR TITLE
feat: support trailing line comment for mage:import

### DIFF
--- a/mage/import_test.go
+++ b/mage/import_test.go
@@ -285,6 +285,26 @@ func TestMageImportsOneLine(t *testing.T) {
 		t.Fatalf("expected: %q got: %q", expected, actual)
 	}
 }
+func TestMageImportsTrailing(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	inv := Invocation{
+		Dir:    "./testdata/mageimport/trailing",
+		Stdout: stdout,
+		Stderr: stderr,
+		Args:   []string{"build"},
+	}
+
+	code := Invoke(inv)
+	if code != 0 {
+		t.Fatalf("expected to exit with code 0, but got %v, stderr:\n%s", code, stderr)
+	}
+	actual := stdout.String()
+	expected := "build\n"
+	if actual != expected {
+		t.Fatalf("expected: %q got: %q", expected, actual)
+	}
+}
 
 func TestMageImportsTaggedPackage(t *testing.T) {
 	stdout := &bytes.Buffer{}

--- a/mage/testdata/mageimport/trailing/magefile.go
+++ b/mage/testdata/mageimport/trailing/magefile.go
@@ -1,0 +1,5 @@
+// +build mage
+
+package main
+
+import _ "github.com/magefile/mage/mage/testdata/mageimport/oneline/other" //mage:import

--- a/mage/testdata/mageimport/trailing/other/other.go
+++ b/mage/testdata/mageimport/trailing/other/other.go
@@ -1,0 +1,7 @@
+package other
+
+import "fmt"
+
+func Build() {
+	fmt.Println("build")
+}


### PR DESCRIPTION
Currently, `//mage:import` is only read from leading doc comments for an import statement, not trailing line comments. This makes it incompatible with tools like [gosimports](https://github.com/rinchsan/gosimports). It seems reasonable to support line comments too and is luckily not difficult