### PR TITLE
Update documentation to include Windows Magefile Cache

### DIFF
--- a/site/content/environment/_index.en.md
+++ b/site/content/environment/_index.en.md
@@ -14,7 +14,7 @@ Set to "1" or "true" to turn on debug mode (like running with -debug)
 ## MAGEFILE_CACHE
 
 Sets the directory where mage will store binaries compiled from magefiles
-(default is $HOME/.magefile)
+(default is $HOME/. or %USERPROFILE%\magefile)
 
 ## MAGEFILE_GOCMD
 

--- a/site/content/howitworks/_index.en.md
+++ b/site/content/howitworks/_index.en.md
@@ -14,8 +14,9 @@ binary is also used in the hash.
 
 ## Binary Cache
 
-Compiled magefile binaries are stored in $HOME/.magefile.  This location can be
-customized by setting the MAGEFILE_CACHE environment variable.
+Compiled magefile binaries are stored by default in $HOME/.magefile or in
+%USERPROFILE%\magefile.  This location can be customized by setting the
+MAGEFILE_CACHE environment variable.
 
 ## Go Environment
 


### PR DESCRIPTION
Fix for documentation issue: https://github.com/magefile/mage/issues/483
Alternately, the path could be changed to `%USERPROFILE%\.magefile` for Windows, but that could cause issues when upgrading.