### PR TITLE
Correct test input code to support older go versions

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,4 +1,5 @@
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 

--- a/install_test.go
+++ b/install_test.go
@@ -1,4 +1,5 @@
-//+build CI
+//go:build CI
+// +build CI
 
 package main
 

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1741,7 +1741,7 @@ func TestGoModules(t *testing.T) {
 	defer os.RemoveAll(dir)
 	// beware, mage builds in go versions older than 1.17 so both build tag formats need to be present
 	err = ioutil.WriteFile(filepath.Join(dir, "magefile.go"), []byte(`//go:build mage
-//+build mage
+// +build mage
 
 package main
 

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1745,10 +1745,8 @@ func TestGoModules(t *testing.T) {
 
 package main
 
-import "golang.org/x/text/unicode/norm"
-
 func Test() {
-	print("unicode version: " + norm.Version)
+	print("nothing is imported here for >1.17 compatibility")
 }
 `), 0600)
 	if err != nil {

--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1739,7 +1739,9 @@ func TestGoModules(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	err = ioutil.WriteFile(filepath.Join(dir, "magefile.go"), []byte(`//+build mage
+	// beware, mage builds in go versions older than 1.17 so both build tag formats need to be present
+	err = ioutil.WriteFile(filepath.Join(dir, "magefile.go"), []byte(`//go:build mage
+//+build mage
 
 package main
 

--- a/mage/template.go
+++ b/mage/template.go
@@ -3,7 +3,8 @@ package mage
 // this template uses the "data"
 
 // var only for tests
-var mageMainfileTplString = `// +build ignore
+var mageMainfileTplString = `//go:build ignore
+// +build ignore
 
 package main
 

--- a/mage/testdata/alias/magefile.go
+++ b/mage/testdata/alias/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/args/magefile.go
+++ b/mage/testdata/args/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/command.go
+++ b/mage/testdata/command.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/compiled/custom.go
+++ b/mage/testdata/compiled/custom.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 // Compiled package description.

--- a/mage/testdata/context/context.go
+++ b/mage/testdata/context/context.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/error.go
+++ b/mage/testdata/error.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/func.go
+++ b/mage/testdata/func.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/goos_magefiles/magefile_nonwindows.go
+++ b/mage/testdata/goos_magefiles/magefile_nonwindows.go
@@ -1,3 +1,4 @@
+//go:build mage && !windows
 // +build mage,!windows
 
 package main

--- a/mage/testdata/goos_magefiles/magefile_windows.go
+++ b/mage/testdata/goos_magefiles/magefile_windows.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/invalid_alias/magefile.go
+++ b/mage/testdata/invalid_alias/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/keep_flag/magefile.go
+++ b/mage/testdata/keep_flag/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/list/command.go
+++ b/mage/testdata/list/command.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 // This is a comment on the package which should get turned into output with the

--- a/mage/testdata/mageimport/magefile.go
+++ b/mage/testdata/mageimport/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/mageimport/oneline/magefile.go
+++ b/mage/testdata/mageimport/oneline/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/mageimport/samenamespace/duptargets/magefile.go
+++ b/mage/testdata/mageimport/samenamespace/duptargets/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package sametarget

--- a/mage/testdata/mageimport/samenamespace/uniquetargets/magefile.go
+++ b/mage/testdata/mageimport/samenamespace/uniquetargets/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/mageimport/tagged/magefile.go
+++ b/mage/testdata/mageimport/tagged/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/mageimport/tagged/pkg/mage.go
+++ b/mage/testdata/mageimport/tagged/pkg/mage.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package pkg
 

--- a/mage/testdata/mageimport/trailing/magefile.go
+++ b/mage/testdata/mageimport/trailing/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/main.go
+++ b/mage/testdata/main.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/mage/testdata/mixed_lib_files/mage_helpers.go
+++ b/mage/testdata/mixed_lib_files/mage_helpers.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/mixed_lib_files/magefile.go
+++ b/mage/testdata/mixed_lib_files/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/mixed_lib_files/subdir/magefile.go
+++ b/mage/testdata/mixed_lib_files/subdir/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/mixed_main_files/mage_helpers.go
+++ b/mage/testdata/mixed_main_files/mage_helpers.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/mixed_main_files/magefile.go
+++ b/mage/testdata/mixed_main_files/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/namespaces/magefile.go
+++ b/mage/testdata/namespaces/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/no_default/magefile.go
+++ b/mage/testdata/no_default/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/onlyStdLib/command.go
+++ b/mage/testdata/onlyStdLib/command.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/panic.go
+++ b/mage/testdata/panic.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/mage/testdata/setdir/setdir.go
+++ b/mage/testdata/setdir/setdir.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/setworkdir/magefile.go
+++ b/mage/testdata/setworkdir/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/signals/signals.go
+++ b/mage/testdata/signals/signals.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/transitiveDeps/magefile.go
+++ b/mage/testdata/transitiveDeps/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/mage/testdata/wrong_dep/magefile.go
+++ b/mage/testdata/wrong_dep/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/parse/testdata/alias.go
+++ b/parse/testdata/alias.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/parse/testdata/command.go
+++ b/parse/testdata/command.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/parse/testdata/func.go
+++ b/parse/testdata/func.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/parse/testdata/importself/magefile.go
+++ b/parse/testdata/importself/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/parse/testdata/repeating_synopsis.go
+++ b/parse/testdata/repeating_synopsis.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/parse/testdata/subcommand_1.9.go
+++ b/parse/testdata/subcommand_1.9.go
@@ -1,4 +1,5 @@
-//+build mage,go1.9
+//go:build mage && go1.9
+// +build mage,go1.9
 
 package main
 

--- a/parse/testdata/subcommands.go
+++ b/parse/testdata/subcommands.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main

--- a/site/content/zeroInstall/_index.en.md
+++ b/site/content/zeroInstall/_index.en.md
@@ -16,6 +16,7 @@ Now you can `go run mage.go <target>` and it'll work just as if you ran
 `mage <target>`:
 
 ```go
+//go:build ignore
 // +build ignore
 
 package main


### PR DESCRIPTION
Samples used for testing need to have build tags for new and old style:

```
//go:build tag
// +build tag
```

The particular problem here, seems to be that 1.16 was actually importing the package referred in the `TestGoModules` test (`import "golang.org/x/text/unicode/norm"`) which, in the CI system's version lacks an old style go tag comment. Hence go complaining of a `//go:build` without a `// +build`. I made all files bi-tagged for consistency.