### PR TITLE
Draft attempt at extra args

### DIFF
--- a/mage/main.go
+++ b/mage/main.go
@@ -119,6 +119,10 @@ type Invocation struct {
 	GoCmd      string        // the go binary command to run
 	CacheDir   string        // the directory where we should store compiled binaries
 	HashFast   bool          // don't rely on GOCACHE, just hash the magefiles
+
+	// all the arguments that came after --, we do not do any kind of parsing on them as
+	// they are intended for a subprocess and we know nothing about them
+	ExtraArgs []string
 }
 
 // MagefilesDirName is the name of the default folder to look for if no directory was specified,
@@ -296,7 +300,23 @@ Options:
 		return inv, cmd, errors.New("-goos and -goarch only apply when running with -compile")
 	}
 
-	inv.Args = fs.Args()
+	var extraArgs []string
+	extraArgsFound := false
+	for _, arg := range fs.Args() {
+		// we do not really care about args before this point, this is where extra args begin
+		if arg == "--" {
+			extraArgsFound = true
+			continue
+		}
+		// all args before -- are the positional args that go to mage
+		if !extraArgsFound {
+			inv.Args = append(inv.Args, arg)
+			continue
+		}
+		// now we parse all that comes after --
+		extraArgs = append(extraArgs, arg)
+	}
+	inv.ExtraArgs = extraArgs
 	if inv.Help && len(inv.Args) > 1 {
 		return inv, cmd, errors.New("-h can only show help for a single target")
 	}

--- a/mage/template.go
+++ b/mage/template.go
@@ -35,6 +35,7 @@ func main() {
 		Help          bool          // print out help for a specific target
 		Timeout       time.Duration // set a timeout to running the targets
 		Args          []string      // args contain the non-flag command-line arguments
+        ExtraArgs     []string      // extraArgs contain the command-line arguments after the "--" separator
 	}
 
 	parseBool := func(env string) bool {
@@ -90,7 +91,23 @@ Options:
 		// flag will have printed out an error already.
 		return
 	}
-	args.Args = fs.Args()
+	var extraArgs []string
+	extraArgsFound := false
+	for _, arg := range fs.Args() {
+		// we do not really care about args before this point, this is where extra args begin
+		if arg == "--" {
+			extraArgsFound = true
+			continue
+		}
+		// all args before -- are the positional args that go to mage
+		if !extraArgsFound {
+			args.Args = append(args.Args, arg)
+			continue
+		}
+		// now we parse all that comes after --
+		extraArgs = append(extraArgs, arg)
+	}
+	args.ExtraArgs = extraArgs
 	if args.Help && len(args.Args) == 0 {
 		fs.Usage()
 		return

--- a/mg/extra_args.go
+++ b/mg/extra_args.go
@@ -1,0 +1,3 @@
+package mg
+
+type ExtraArgs []string

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -116,6 +116,10 @@ func (f Function) ExecCode() string {
 	var parseargs string
 	for x, arg := range f.Args {
 		switch arg.Type {
+		case "mg.ExtraArgs":
+			parseargs += fmt.Sprintf(`
+			arg%d := args.ExtraArgs
+			x++`, x)
 		case "string":
 			parseargs += fmt.Sprintf(`
 			arg%d := args.Args[x]
@@ -847,4 +851,5 @@ var argTypes = map[string]string{
 	"int":              "int",
 	"&{time Duration}": "time.Duration",
 	"bool":             "bool",
+	"mg.ExtraArgs":     "mg.ExtraArgs",
 }


### PR DESCRIPTION
So, this is an idea mostly, i have not been able to test this as running `mage` just gets the `mg` from upstream, perhaps i should not use upstream?

The idea is to support this:

```go
//go:build mage
// +build mage

package main

import (
	"fmt"

	mg "../../go/github.com/magefile/mage/mg"
)

func TargetOne(extra mg.ExtraArgs) error {
	fmt.Printf("%#v\n", extra)
}
```

where ideally extra would become a string slice  `[]string{"-baz", "blah"}` after calling `mage targetone foo bar -- -baz blah`