### PR TITLE
chore(docs): updated README and site to include installation using go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ cd $GOPATH/src/github.com/magefile/mage
 go run bootstrap.go
 ```
 
+**Using Go Install**
+
+```
+go install github.com/magefile/mage@latest
+mage -init
+```
+
+Instead of the @latest tag, you can specify the desired version, for example:
+
+```
+go install github.com/magefile/mage@v1.15.0
+```
+
 **Using Go Modules**
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and Mage automatically uses them as Makefile-like runnable targets.
 Mage has no dependencies outside the Go standard library, and builds with Go 1.7
 and above (possibly even lower versions, but they're not regularly tested).
 
-**Using GOPATH**
+**Using GOPATH with go version < 1.17**
 
 ```
 go get -u -d github.com/magefile/mage
@@ -21,7 +21,7 @@ cd $GOPATH/src/github.com/magefile/mage
 go run bootstrap.go
 ```
 
-**Using Go Install**
+**Using Go Install with go version >= 1.18**
 
 ```
 go install github.com/magefile/mage@latest

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -14,12 +14,24 @@ and Mage automatically uses them as Makefile-like runnable targets.
 Mage has no dependencies outside the Go standard library, and builds with Go 1.7
 and above (possibly even lower versions, but they're not regularly tested).
 
-#### Using Go Modules (Recommended)
+#### Using Go Modules (Recommended with go version < 1.17)
 
 ```plain
 git clone https://github.com/magefile/mage
 cd mage
 go run bootstrap.go
+```
+
+#### Using Go Install (Recommended with go version >= [1.17](https://go.dev/doc/go-get-install-deprecation))
+
+```plain
+go install github.com/magefile/mage@latest
+mage -init
+```
+Instead of the @latest tag, you can specify the desired version, for example:
+
+```plain
+go install github.com/magefile/mage@v1.15.0
 ```
 
 #### Using GOPATH

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -14,7 +14,7 @@ and Mage automatically uses them as Makefile-like runnable targets.
 Mage has no dependencies outside the Go standard library, and builds with Go 1.7
 and above (possibly even lower versions, but they're not regularly tested).
 
-#### Using Go Modules (Recommended with go version < 1.17)
+#### Using Go Modules (With go version < 1.17)
 
 ```plain
 git clone https://github.com/magefile/mage
@@ -22,7 +22,7 @@ cd mage
 go run bootstrap.go
 ```
 
-#### Using Go Install (Recommended with go version >= [1.17](https://go.dev/doc/go-get-install-deprecation))
+#### Using Go Install (With go version >= [1.17](https://go.dev/doc/go-get-install-deprecation))
 
 ```plain
 go install github.com/magefile/mage@latest


### PR DESCRIPTION
Updated docs and website index with instructions on how to install mage using the `go install` command