### PR TITLE
Allow escaping "$" in command arguments

### DIFF
--- a/sh/cmd_test.go
+++ b/sh/cmd_test.go
@@ -68,5 +68,34 @@ func TestAutoExpand(t *testing.T) {
 	if s != "baz" {
 		t.Fatalf(`Expected "baz" but got %q`, s)
 	}
+}
 
+func TestAutoExpandPrecedent(t *testing.T) {
+	// Environment variables passed to OutputWith should take precedence
+	// over any variables set in the actual environment.
+	if err := os.Setenv("MAGE_FOO", "wrong"); err != nil {
+		t.Fatal(err)
+	}
+	s, err := OutputWith(map[string]string{
+		"MAGE_FOO": "right",
+	}, "echo", "$MAGE_FOO")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "right" {
+		t.Fatalf(`Expected "right" but got %q`, s)
+	}
+}
+
+func TestEscapeExpand(t *testing.T) {
+	s, err := OutputWith(map[string]string{
+		"MAGE_BAR": "bar",
+	}, os.Args[0], "-printArgs", "foo${MAGE_BAR}baz", Escape("foo${MAGE_BAR}baz"), `foo\$${MAGE_BAR}\\baz`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "[foobarbaz foo${MAGE_BAR}baz foo$bar\\baz]"
+	if s != expected {
+		t.Fatalf(`Expected %q but got %q`, expected, s)
+	}
 }


### PR DESCRIPTION
The `sh.Exec` family of functions used to use `os.Expand` to expand environment variables in command arguments, but that function offers no escape syntax -- no way to avoid expanding dollar signs that the caller really wants to include on the command line. This commit implements a new, mostly compatible `Expand` function to allow escaping the environment-variable syntax, plus an accompanying `Escape` function to producing escaped strings.

This technically breaks backward compatibility; any existing code that has used the sequence "\\" or "\$" in its command arguments will need to be updated. Although the compatibility argument prevents `os.Expand` from changing, documentation for `sh.Exec` hasn't actually stated that it follows all the same rules as `os.Expand`, so it's possible to view this change as merely a bugfix, formalizing a new syntax that had not previously been established.

Fixes #434