### PR TITLE
getFunction() ignoring receiver on imports

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -671,7 +671,7 @@ func getFunction(exp ast.Expr, pi *PkgInfo) (*Function, error) {
 			for _, imp := range pi.Imports {
 				if firstname == imp.Name {
 					for _, f := range imp.Info.Funcs {
-						if funcname == f.Name {
+						if funcname == f.Name && f.Receiver == "" {
 							return f, nil
 						}
 					}


### PR DESCRIPTION
`getFunction()` ignores the receiver, selecting the first matching function name regardless of scope.

Fixes #508