### PR TITLE
fix: escape backticks in package comment for generated code

### DIFF
--- a/mage/template.go
+++ b/mage/template.go
@@ -224,7 +224,7 @@ Options:
 	}
 
 	list := func() error {
-		{{with .Description}}_fmt.Println(` + "`{{.}}\n`" + `)
+		{{with .Description}}_fmt.Println({{printf "%q" .}} + "\n")
 		{{- end}}
 		{{- $default := .DefaultFunc}}
 		targets := map[string]string{


### PR DESCRIPTION
Fixes #537

## Problem

When a magefile's package comment contains backticks, the generated `mage_output_file.go` breaks:

```go
// Source magefile:
// This is a magefile, to be called with `go tool mage`.
package main

// Generated code (broken):
_fmt.Println(`This is a magefile, to be called with `go tool mage`.
`)
```

The backticks in the comment terminate the raw string literal, producing invalid Go.

## Fix

Use `%q` (Go quoted string) instead of embedding in a raw backtick literal:

```go
// Before:
_fmt.Println(`{{.}}\n`)

// After:
_fmt.Println({{printf "%q" .}} + "\n")
```

This properly escapes any special characters including backticks.

## Testing

All mage tests pass.